### PR TITLE
Skip error handling: my $e = ERR_get_error() = 0

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -69,11 +69,11 @@ method read(Int $n, Bool :$bin) {
 
     unless $read > 0 {
         my $e = OpenSSL::Err::ERR_get_error();
-        repeat {
+        while $e != 0 && $e != 4294967296 {
             say "err code: $e";
             say OpenSSL::Err::ERR_error_string($e);
             $e = OpenSSL::Err::ERR_get_error();
-        } while $e != 0 && $e != 4294967296;
+        }
     }
 
     my $buf = buf8.new($carray[^$read]) if $bin.defined;


### PR DESCRIPTION
    Manual:ERR_get_error(3): The error code, or 0 if there is no error in the queue.
repeat {} executes the block once regardless of the conditional, so non-errors will get output

Heres two examples of the same test being run twice in a row that this pr appears to have fixed:

    localhost:~/perl6/zef$ perl6 -Ilib  t/zef-getter.t
    1..3
        ok 1 - Created getter
        ok 2 - no plugins loaded
    err code: 0
    Segmentation fault
    localhost:~/perl6/zef$ perl6 -Ilib  t/zef-getter.t
    1..3
        ok 1 - Created getter
        ok 2 - no plugins loaded
    err code: 0
    error:00000000:lib(0):func(0):reason(0)
        ok 3 - Used default .get method
        ok 4 - Modules were fetched
        ok 5 - deleted test modules
        1..5