### PR TITLE
Implement wrapping of Perl 6 sockets using BIO functions

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -184,7 +184,7 @@ method read(Int $n, Bool :$bin) {
 
     my $buf = buf8.new($carray[^$read]) if $bin.defined;
 
-    return $bin.defined ?? $buf !! $carray[^$read]>>.chr.join;
+    return $bin ?? $buf !! $carray[^$read]>>.chr.join;
 }
 
 method use-certificate-file(Str $file) {

--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -217,6 +217,10 @@ method ctx-free {
 
 method ssl-free {
     OpenSSL::SSL::SSL_free($!ssl);
+    if $.using-bio {
+        # $.internal-bio is freed by the SSL_free call
+        OpenSSL::Bio::BIO_free($.net-bio);
+    }
 }
 
 method close {

--- a/lib/OpenSSL/Bio.pm6
+++ b/lib/OpenSSL/Bio.pm6
@@ -40,5 +40,6 @@ class BIO is repr('CStruct') {
 }
 
 our sub BIO_new_bio_pair(CArray[OpaquePointer], int, CArray[OpaquePointer], int --> int32) is native($lib) { ... }
+our sub BIO_free(OpaquePointer) is native($lib) { ... }
 our sub BIO_read(OpaquePointer, CArray[uint8], int32 --> int32) is native($lib) { ... }
 our sub BIO_write(OpaquePointer, CArray[uint8], int32 --> int32) is native($lib) { ... }

--- a/lib/OpenSSL/Bio.pm6
+++ b/lib/OpenSSL/Bio.pm6
@@ -1,5 +1,15 @@
 module OpenSSL::Bio;
 
+my Str $lib;
+BEGIN {
+    if $*VM.config<dll> ~~ /dll/ {
+        # we're on windows, different library name
+        $lib = 'ssleay32.dll';
+    } else {
+        $lib = 'libssl';
+    }
+}
+
 use NativeCall;
 
 class BIO_METHOD is repr('CStruct') {
@@ -28,3 +38,7 @@ class BIO is repr('CStruct') {
 
     # ex_data ?
 }
+
+our sub BIO_new_bio_pair(CArray[OpaquePointer], int64, CArray[OpaquePointer], int64 --> int32) is native($lib) { ... }
+our sub BIO_read(OpaquePointer, CArray[uint8], int32 --> int32) is native($lib) { ... }
+our sub BIO_write(OpaquePointer, CArray[uint8], int32 --> int32) is native($lib) { ... }

--- a/lib/OpenSSL/Bio.pm6
+++ b/lib/OpenSSL/Bio.pm6
@@ -4,7 +4,7 @@ my Str $lib;
 BEGIN {
     if $*VM.config<dll> ~~ /dll/ {
         # we're on windows, different library name
-        $lib = 'ssleay32.dll';
+        $lib = 'libeay32.dll';
     } else {
         $lib = 'libssl';
     }
@@ -39,6 +39,6 @@ class BIO is repr('CStruct') {
     # ex_data ?
 }
 
-our sub BIO_new_bio_pair(CArray[OpaquePointer], int64, CArray[OpaquePointer], int64 --> int32) is native($lib) { ... }
+our sub BIO_new_bio_pair(CArray[OpaquePointer], int, CArray[OpaquePointer], int --> int32) is native($lib) { ... }
 our sub BIO_read(OpaquePointer, CArray[uint8], int32 --> int32) is native($lib) { ... }
 our sub BIO_write(OpaquePointer, CArray[uint8], int32 --> int32) is native($lib) { ... }

--- a/lib/OpenSSL/SSL.pm6
+++ b/lib/OpenSSL/SSL.pm6
@@ -59,3 +59,4 @@ our sub SSL_write(SSL, CArray[uint8], int32) returns int32 is native($lib) { ...
 our sub SSL_set_connect_state(SSL) is native($lib)                         { ... }
 our sub SSL_set_accept_state(SSL) is native($lib)                          { ... }
 
+our sub SSL_set_bio(SSL, OpaquePointer, OpaquePointer) returns int32 is native($lib) { ... }


### PR DESCRIPTION
Can now do `$ssl.set-socket(IO::Socket::INET.new(...))` instead of set-fd.

This removes the need to do a C-level connect, and also allows plain-text communication before negotiating a secure connection.
