### PR TITLE
Switch from CArray to Buf for bulk data

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -95,8 +95,7 @@ method bio-read {
         if $!bio-read-buf.bytes == 0 {
             $!bio-read-buf = $.net-read.();
         }
-        my $cbuf = buf-to-carray($!bio-read-buf);
-        my $bytes = OpenSSL::Bio::BIO_write($.net-bio, $cbuf, $!bio-read-buf.bytes);
+        my $bytes = OpenSSL::Bio::BIO_write($.net-bio, $!bio-read-buf, $!bio-read-buf.bytes);
         $!bio-read-buf = $!bio-read-buf.subbuf($bytes);
     }
 }
@@ -176,7 +175,7 @@ multi method write(Blob $b) {
 method read(Int $n, Bool :$bin) {
     my int32 $count = $n;
     my $carray = buf8.new;
-    $carray[$count-1] = 0;
+    $carray[$n-1] = 0;
     my $read;
     loop {
         $read = OpenSSL::SSL::SSL_read($!ssl, $carray, $count);
@@ -186,7 +185,8 @@ method read(Int $n, Bool :$bin) {
         last unless $e > 0;
     }
 
-    my $buf = $carray.subbuf(0, $read);
+    my $buf = buf8.new;
+    $buf = $carray.subbuf(0, $read) if $read >= 0;
 
     return $bin ?? $buf !! $buf.decode;
 }

--- a/lib/OpenSSL/Bio.pm6
+++ b/lib/OpenSSL/Bio.pm6
@@ -41,5 +41,5 @@ class BIO is repr('CStruct') {
 
 our sub BIO_new_bio_pair(CArray[OpaquePointer], int, CArray[OpaquePointer], int --> int32) is native($lib) { ... }
 our sub BIO_free(OpaquePointer) is native($lib) { ... }
-our sub BIO_read(OpaquePointer, CArray[uint8], int32 --> int32) is native($lib) { ... }
-our sub BIO_write(OpaquePointer, CArray[uint8], int32 --> int32) is native($lib) { ... }
+our sub BIO_read(OpaquePointer, Blob, int32 --> int32) is native($lib) { ... }
+our sub BIO_write(OpaquePointer, Blob, int32 --> int32) is native($lib) { ... }

--- a/lib/OpenSSL/SSL.pm6
+++ b/lib/OpenSSL/SSL.pm6
@@ -54,8 +54,8 @@ our sub SSL_free(SSL) is native($lib)                                      { ...
 our sub SSL_get_error(SSL, int32) returns int32 is native($lib)            { ... }
 our sub SSL_accept(SSL) returns int32 is native($lib)                      { ... }
 our sub SSL_connect(SSL) returns int32 is native($lib)                     { ... }
-our sub SSL_read(SSL, CArray[uint8], int32) returns int32 is native($lib)  { ... }
-our sub SSL_write(SSL, CArray[uint8], int32) returns int32 is native($lib) { ... }
+our sub SSL_read(SSL, Blob, int32) returns int32 is native($lib)  { ... }
+our sub SSL_write(SSL, Blob, int32) returns int32 is native($lib) { ... }
 our sub SSL_set_connect_state(SSL) is native($lib)                         { ... }
 our sub SSL_set_accept_state(SSL) is native($lib)                          { ... }
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,7 +1,0 @@
-all: %DESTDIR%/libbuf%SO%
-
-%DESTDIR%/libbuf%SO%: libbuf%O%
-	    %LD% %LDSHARED% %LDFLAGS% %LIBS% %LDOUT%%DESTDIR%/libbuf%SO% libbuf%O%
-
-libbuf%O%: libbuf.c
-	    %CC% -c %CCSHARED% %CCFLAGS% %CCOUT%libbuf%O% libbuf.c

--- a/src/libbuf.c
+++ b/src/libbuf.c
@@ -1,5 +1,0 @@
-#include <stdlib.h>
-
-char *get_buf(int n) {
-    return (char *) malloc(n * sizeof(char));
-}


### PR DESCRIPTION
Enabled by recent NativeCall changes, should have a noticeable performance
improvement.

Also adds write() method for binary data.