### PR TITLE
work around malformed utf-8 in test; s/decode/unpack/

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -194,7 +194,7 @@ method read(Int $n, Bool :$bin) {
         last unless $e > 0;
     }
 
-    return $bin ?? $buf !! $buf.decode;
+    return $bin ?? $buf !! $buf.unpack('A*');
 }
 
 method use-certificate-file(Str $file) {


### PR DESCRIPTION
`.decode` defaults to utf-8, and I started getting a malformed utf-8 error during 02-socket.t
    
    .unpack('A*')
    .decode('latin-1') 
    $buf[^$buf.elems]>>.chr.join

seem to all be ok solutions for now. 

    Malformed UTF-8 at line 1 col 210
      in method decode at src/gen/m-CORE.setting:6314
      in method read at /home/nickl/perl6/openssl/lib/OpenSSL.pm6:178
      in block <unit> at t/02-socket.t:15

It is strange though, because that test was passing for me yesterday.