### PR TITLE
Buffer $n bytes before returning

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -199,7 +199,7 @@ method read(Int $n, Bool :$bin) {
 
         my $e = 0;
         $e = $.handle-error($read) if $read < 0;
-        last unless $e > 0;
+        last if $e <= 0 || $total-read >= $n;
     }
 
     return $bin ?? $buf !! $buf.decode('latin-1');


### PR DESCRIPTION
Seems like it may be the cause of https://github.com/sergot/http-useragent/issues/105 where a call to `recv($chunked-size)` might return less than `$chunked-size` bytes. This looks like it should be handled in `IO::Socket::SSL` already so it might not be a valid PR; Input is needed