### PR TITLE
Fix ERR_get_error return type, which should be unsigned long accordin…

### DIFF
--- a/lib/OpenSSL/Err.pm6
+++ b/lib/OpenSSL/Err.pm6
@@ -5,4 +5,4 @@ use NativeCall;
 
 our sub ERR_error_string(int32 $e, Str $ret) returns Str is native(&gen-lib) { ... };
 
-our sub ERR_get_error() returns Int is native(&gen-lib) { ... };
+our sub ERR_get_error() returns ulonglong is native(&gen-lib) { ... };


### PR DESCRIPTION
…g to https://www.openssl.org/docs/manmaster/crypto/ERR_get_error.html

NativeCall commit which introduces the reason to do so: https://github.com/rakudo/rakudo/commit/f5903a5471ecb09e71b93c809dc5f87a6d047dfe