### PR TITLE
Fix on OS X

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -49,12 +49,13 @@ method new(Bool :$client = False, Int :$version?) {
                 $method = ($client ?? OpenSSL::Method::TLSv1_2_client_method() !! OpenSSL::Method::TLSv1_2_server_method());
             }
             default {
-                $method = ($client ?? OpenSSL::Method::TLSv1_2_client_method() !! OpenSSL::Method::TLSv1_2_server_method());
+                $method = try {$client ?? OpenSSL::Method::TLSv1_2_client_method() !! OpenSSL::Method::TLSv1_2_server_method()} || try {$client ?? OpenSSL::Method::TLSv1_client_method() !! OpenSSL::Method::TLSv1_server_method()}  ; 
             }
         }
     }
     else {
-        $method = $client ?? OpenSSL::Method::TLSv1_2_client_method() !! OpenSSL::Method::TLSv1_2_server_method();
+        #$method = $client ?? OpenSSL::Method::TLSv1_2_client_method() !! OpenSSL::Method::TLSv1_2_server_method();
+        $method = try {$client ?? OpenSSL::Method::TLSv1_2_client_method() !! OpenSSL::Method::TLSv1_2_server_method()} || try {$client ?? OpenSSL::Method::TLSv1_client_method() !! OpenSSL::Method::TLSv1_server_method()}  ;
     }
     my $ctx     = OpenSSL::Ctx::SSL_CTX_new( $method );
     my $ssl     = OpenSSL::SSL::SSL_new( $ctx );

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -9,7 +9,13 @@ isa-ok $ssl, OpenSSL, 'new 1/3';
 is $ssl.ctx.method.version, 769, 'new 2/3';
 
 $ssl = OpenSSL.new(:client);
-is $ssl.ctx.method.version, 771, 'new 3/3';
+try { OpenSSL::Method::TLSv1_2_client_method() };
+if $!.defined {
+    is $ssl.ctx.method.version, 769, 'new 3/3';
+}
+else {
+    is $ssl.ctx.method.version, 771, 'new 3/3';
+}
 
 # wrong fd here
 ok $ssl.set-fd(111), 'set-fd';


### PR DESCRIPTION
OS X ships with OpenSSL 0.9.8 which doesn't support TLSv1.2 and this module fails to  install as a result.

Fix is testing for TLSv1.2 support before using it for the "default"
case and falling back to TLSv1.0 if it's not supported.