### PR TITLE
proposed support for aes128 and aes192 encryption

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,6 @@
 {
     "name"      : "OpenSSL",
-    "version"   : "0.1.2",
+    "version"   : "0.1.3",
     "author"    : "github:sergot",
     "description"   : "OpenSSL bindings",
     "depends"   : ["Digest"],

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Public key signing tools
 
 ## OpenSSL::CryptTools
 
-Symmetric encryption tools (currently only AES256 encrypt/decrypt)
+Symmetric encryption tools (currently only AES256/192/128 encrypt/decrypt)
 
     use OpenSSL::CryptTools;
 

--- a/lib/OpenSSL/CryptTools.pm6
+++ b/lib/OpenSSL/CryptTools.pm6
@@ -3,16 +3,32 @@ use NativeCall;
 
 unit module OpenSSL::CryptTools;
 
-our sub encrypt(Blob $plaintext, :$key, :$iv, :$aes256!) is export {
-    my $ctx = OpenSSL::EVP::EVP_CIPHER_CTX_new();
+our proto sub encrypt(|) is export {*}
 
+multi sub encrypt(:$aes256!, |c) is export {
     my $cipher = OpenSSL::EVP::EVP_aes_256_cbc();
-    if $key.bytes != 256/8 {
-        die "Key is not 256 bits";
+    encrypt(:$cipher, |c);
+}
+multi sub encrypt(:$aes192!, |c) is export {
+    my $cipher = OpenSSL::EVP::EVP_aes_192_cbc();
+    encrypt(:$cipher, |c);
+}
+multi sub encrypt(:$aes128!, |c) is export {
+    my $cipher = OpenSSL::EVP::EVP_aes_128_cbc();
+    encrypt(:$cipher, |c);
+}
+
+multi sub encrypt(Blob $plaintext, :$key, :$iv, :$cipher!) is export {
+    my $ctx = OpenSSL::EVP::EVP_CIPHER_CTX_new();
+    my $evp = nativecast(OpenSSL::EVP::evp_cipher_st, $cipher);
+
+    if $key.bytes != $evp.key_len {
+        die "Key is not {$evp.key_len * 8} bits";
     }
-    if $iv.bytes != 128/8 {
-        die "Key is not 128 bits";
+    if $iv.bytes != $evp.iv_len {
+        die "Key is not {$evp.iv_len * 8} bits";
     }
+
     # way bigger than needed
     my $bufsize = $plaintext.bytes * 2;
     $bufsize = 64 if $bufsize < 64;
@@ -36,16 +52,32 @@ our sub encrypt(Blob $plaintext, :$key, :$iv, :$aes256!) is export {
     return $out;
 }
 
-our sub decrypt(Blob $ciphertext, :$key, :$iv, :$aes256!) is export {
-    my $ctx = OpenSSL::EVP::EVP_CIPHER_CTX_new();
+our proto sub decrypt(|) is export {*}
 
+multi sub decrypt(:$aes256!, |c) is export {
     my $cipher = OpenSSL::EVP::EVP_aes_256_cbc();
-    if $key.bytes != 256/8 {
-        die "Key is not 256 bits";
+    decrypt(:$cipher, |c);
+}
+multi sub decrypt(:$aes192!, |c) is export {
+    my $cipher = OpenSSL::EVP::EVP_aes_192_cbc();
+    decrypt(:$cipher, |c);
+}
+multi sub decrypt(:$aes128!, |c) is export {
+    my $cipher = OpenSSL::EVP::EVP_aes_128_cbc();
+    decrypt(:$cipher, |c);
+}
+
+multi sub decrypt(Blob $ciphertext, :$key, :$iv, :$cipher!) is export {
+    my $ctx = OpenSSL::EVP::EVP_CIPHER_CTX_new();
+    my $evp = nativecast(OpenSSL::EVP::evp_cipher_st, $cipher);
+
+    if $key.bytes != $evp.key_len {
+        die "Key is not {$evp.key_len * 8} bits";
     }
-    if $iv.bytes != 128/8 {
-        die "Key is not 128 bits";
+    if $iv.bytes != $evp.iv_len {
+        die "Key is not {$evp.iv_len * 8} bits";
     }
+
     # way bigger than needed
     my $bufsize = $ciphertext.bytes * 2;
     $bufsize = 64 if $bufsize < 64;

--- a/lib/OpenSSL/CryptTools.pm6
+++ b/lib/OpenSSL/CryptTools.pm6
@@ -26,7 +26,7 @@ multi sub encrypt(Blob $plaintext, :$key, :$iv, :$cipher!) is export {
         die "Key is not {$evp.key_len * 8} bits";
     }
     if $iv.bytes != $evp.iv_len {
-        die "Key is not {$evp.iv_len * 8} bits";
+        die "IV is not {$evp.iv_len * 8} bits";
     }
 
     # way bigger than needed
@@ -75,7 +75,7 @@ multi sub decrypt(Blob $ciphertext, :$key, :$iv, :$cipher!) is export {
         die "Key is not {$evp.key_len * 8} bits";
     }
     if $iv.bytes != $evp.iv_len {
-        die "Key is not {$evp.iv_len * 8} bits";
+        die "IV is not {$evp.iv_len * 8} bits";
     }
 
     # way bigger than needed

--- a/lib/OpenSSL/EVP.pm6
+++ b/lib/OpenSSL/EVP.pm6
@@ -17,6 +17,22 @@ our sub EVP_DecryptInit(OpaquePointer, OpaquePointer, Blob, Blob --> int32) is n
 our sub EVP_DecryptUpdate(OpaquePointer, Blob, CArray[int32], Blob, int32 --> int32) is native(&gen-lib) { ... }
 our sub EVP_DecryptFinal(OpaquePointer, Blob, CArray[int32] --> int32) is native(&gen-lib) { ... }
 
+class evp_cipher_st is repr('CStruct') {
+    has int32 $.nid;
+    has int32 $.block_size;
+    # Default value for variable length ciphers
+    has int32 $.key_len;
+    has int32 $.iv_len;
+    # Various flags
+    has ulong $.flags;
+    # + various other fields
+
+    method is-variable-length returns Bool {
+        constant EVP_CIPH_VARIABLE_LENGTH = 0x8;
+        ? ($!flags +& EVP_CIPH_VARIABLE_LENGTH);
+    }
+}
+
 # ciphers
 our sub EVP_aes_128_cbc( --> OpaquePointer) is native(&gen-lib) { ... }
 our sub EVP_aes_192_cbc( --> OpaquePointer) is native(&gen-lib) { ... }


### PR DESCRIPTION
- encrypt and decrypt methods are now multisubs with :aes128 and :aes192 candidates
- these now call :cipher candidates for more generalized encryptioon/decryption
- I've defined a CStruct for evp_cipher_st from openssl/evp.h to get key and iv lengths
- tests added to t/07-crypt.h. Existing tests refactored to avoid experimental Buf.unpack

This being use in https://github.com/p6-pdf/perl6-PDF-Tools/blob/openssl-crypt/lib/PDF/Storage/Crypt.pm for AES128 encrypted PDF's. 