### PR TITLE
Provide sha1, sha256 and md5 digest functions.

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,14 +1,15 @@
 {
     "name"      : "OpenSSL",
-    "version"   : "0.1.3",
+    "version"   : "0.1.4",
     "author"    : "github:sergot",
     "description"   : "OpenSSL bindings",
-    "depends"   : ["Digest"],
+    "depends"   : [],
     "provides" : {
         "OpenSSL"             : "lib/OpenSSL.pm6",
         "OpenSSL::Bio"        : "lib/OpenSSL/Bio.pm6",
         "OpenSSL::Cipher"     : "lib/OpenSSL/Cipher.pm6",
         "OpenSSL::CryptTools" : "lib/OpenSSL/CryptTools.pm6",
+        "OpenSSL::Digest"     : "lib/OpenSSL/Digest.pm6",
         "OpenSSL::Ctx"        : "lib/OpenSSL/Ctx.pm6",
         "OpenSSL::Err"        : "lib/OpenSSL/Err.pm6",
         "OpenSSL::EVP"        : "lib/OpenSSL/EVP.pm6",

--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ Symmetric encryption tools (currently only AES256/192/128 encrypt/decrypt)
                             :aes256,
                             :iv(("0" x 16).encode),
                             :key(('x' x 32).encode));
+
+## OpenSSL::Digest
+
+Digest Functions (currently only md5/sha1/sha256)
+
+    use OpenSSL::Digest;
+    my Blob $digest = md5("xyz".encode);

--- a/lib/OpenSSL/Digest.pm6
+++ b/lib/OpenSSL/Digest.pm6
@@ -1,0 +1,31 @@
+use OpenSSL::NativeLib;
+use NativeCall;
+
+unit module OpenSSL::Digest;
+
+our constant MD5_DIGEST_LENGTH    = 16;
+our constant SHA1_DIGEST_LENGTH   = 20;
+our constant SHA256_DIGEST_LENGTH = 32;
+
+sub MD5( Blob, size_t, Blob ) is native(&gen-lib)    { ... }
+sub SHA1( Blob, size_t, Blob ) is native(&gen-lib)   { ... }
+sub SHA256( Blob, size_t, Blob ) is native(&gen-lib) { ... }
+
+sub md5(Blob $msg) is export {
+     my $digest = buf8.new(0 xx MD5_DIGEST_LENGTH);
+     MD5($msg, $msg.bytes, $digest);
+     $digest;
+}
+
+sub sha1(Blob $msg) is export {
+     my $digest = buf8.new(0 xx SHA1_DIGEST_LENGTH);
+     SHA1($msg, $msg.bytes, $digest);
+     $digest;
+}
+
+sub sha256(Blob $msg) is export {
+     my $digest = buf8.new(0 xx SHA256_DIGEST_LENGTH);
+     SHA256($msg, $msg.bytes, $digest);
+     $digest;
+}
+

--- a/lib/OpenSSL/RSATools.pm6
+++ b/lib/OpenSSL/RSATools.pm6
@@ -3,7 +3,7 @@ use OpenSSL::Bio;
 use OpenSSL::PEM;
 use OpenSSL::X509;
 use OpenSSL::EVP;
-use Digest::SHA;
+use OpenSSL::Digest;
 
 use NativeCall;
 

--- a/t/05-digest.t
+++ b/t/05-digest.t
@@ -1,0 +1,16 @@
+use Test;
+use OpenSSL::Digest;
+
+plan 3;
+
+my $test-str = "foo bar";
+my $test-buf = $test-str.encode: 'ascii';
+my $sha1 = [~] .list».fmt: "%02x" given sha1 $test-buf;
+my $sha256 = [~] .list».fmt: "%02x" given sha256 $test-buf;
+
+is $sha1, '3773dea65156909838fa6c22825cafe090ff8030', "sha1";
+is $sha256, 'fbc1a9f858ea9e177916964bd88c3d37b91a1e84412765e29950777f265c4b75', "sha256";
+
+is md5('abc'.encode: 'ascii').list».fmt("%02x").join, '900150983cd24fb0d6963f7d28e17f72', "md5";
+
+# vim: ft=perl6


### PR DESCRIPTION
Use the sha1 and sha256 functions in RSATools and drop the dependency
on the Digest module.

I'm planning to use the md5 function in [PDF::Tools](https://github.com/p6-pdf/perl6-PDF-Tools/tree/openssl-md5). Much faster than the pure perl implementation.