### PR TITLE
Use faster buf8.new multi in read()

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -204,7 +204,9 @@ multi method write(Blob $b) {
 
 method read(Int $n, Bool :$bin) {
     my int32 $count = $n;
-    my $carray = buf8.new(0 xx $n);
+    my int @zeroes;
+    @zeroes[$n - 1] = 0;
+    my $carray = buf8.new(@zeroes);
     my $total-read = 0;
     my $buf = buf8.new;
     loop {


### PR DESCRIPTION
buf8.new has a multi that takes a native array which is much faster.

Passes all the tests.

A profile of `use HTTP::UserAgent; my $ua = HTTP::UserAgent.new; my $response = $ua.get("https://perl6.org"); say $response.content.chars` used to show 1 million+ calls each to `IterationBuffer`'s `push` and `Int`'s `prefix:<-->` and take an average of 2s. After this change it doesn't have either of those 1 million+ calls and takes an average of 1s.