### PR TITLE
Use buf8.allocate instead of buf8.new

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -204,9 +204,7 @@ multi method write(Blob $b) {
 
 method read(Int $n, Bool :$bin) {
     my int32 $count = $n;
-    my int @zeroes;
-    @zeroes[$n - 1] = 0;
-    my $carray = buf8.new(@zeroes);
+    my $carray = buf8.allocate($n);
     my $total-read = 0;
     my $buf = buf8.new;
     loop {

--- a/lib/OpenSSL/Digest.pm6
+++ b/lib/OpenSSL/Digest.pm6
@@ -12,19 +12,19 @@ sub SHA1( Blob, size_t, Blob ) is native(&gen-lib)   { ... }
 sub SHA256( Blob, size_t, Blob ) is native(&gen-lib) { ... }
 
 sub md5(Blob $msg) is export {
-     my $digest = buf8.new(0 xx MD5_DIGEST_LENGTH);
+     my $digest = buf8.allocate(MD5_DIGEST_LENGTH);
      MD5($msg, $msg.bytes, $digest);
      $digest;
 }
 
 sub sha1(Blob $msg) is export {
-     my $digest = buf8.new(0 xx SHA1_DIGEST_LENGTH);
+     my $digest = buf8.allocate(SHA1_DIGEST_LENGTH);
      SHA1($msg, $msg.bytes, $digest);
      $digest;
 }
 
 sub sha256(Blob $msg) is export {
-     my $digest = buf8.new(0 xx SHA256_DIGEST_LENGTH);
+     my $digest = buf8.allocate(SHA256_DIGEST_LENGTH);
      SHA256($msg, $msg.bytes, $digest);
      $digest;
 }


### PR DESCRIPTION
buf8.allocate is even faster than creating the buf with a native int
array, plus the code is a little cleaner/simpler. However, it was
introduced in February 2016, so requires a Rakudo built after then.

Passes all the tests.