### PR TITLE
Add OpenSSL::Digest::MD5

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -22,7 +22,8 @@
         "OpenSSL::Session"    : "lib/OpenSSL/Session.pm6",
         "OpenSSL::Stack"      : "lib/OpenSSL/Stack.pm6",
         "OpenSSL::SSL"        : "lib/OpenSSL/SSL.pm6",
-        "OpenSSL::X509"       : "lib/OpenSSL/X509.pm6"
+        "OpenSSL::X509"       : "lib/OpenSSL/X509.pm6",
+        "OpenSSL::Digest::MD5": "lib/OpenSSL/Digest/MD5.pm6"
     },
     "source-url"    : "git://github.com/sergot/openssl.git",
     "resources" : [ "ssleay32.dll", "libeay32.dll" ]

--- a/README.md
+++ b/README.md
@@ -51,3 +51,16 @@ Digest Functions (currently only md5/sha1/sha256/sha384/sha512)
 
     use OpenSSL::Digest;
     my Blob $digest = md5("xyz".encode);
+
+## OpenSSL::Digest::MD5
+
+OO-Interface supporting incremental digesting
+
+    use OpenSSL::Digest::MD5;
+
+    my $md5 = OpenSSL::Digest::MD5.new; # Create fresh object
+    $md5.add('abc');                    # pass in Str or Blob
+    $md5.add('def');                    # Add some more data
+    my $digest = $md5.hash;             # Blob hash (and reset)
+    $md5.addfile('myfile');             # Read a file
+    my $hexdigest = $md5.hex;           # hex hash  (and reset)

--- a/lib/OpenSSL/Digest/MD5.pm6
+++ b/lib/OpenSSL/Digest/MD5.pm6
@@ -1,0 +1,51 @@
+use OpenSSL::NativeLib;
+use NativeCall;
+
+constant MD5-CTX-SIZE      = 92;
+constant MD5_DIGEST_LENGTH = 16;
+
+class OpenSSL::Digest::MD5
+{
+    has $!context;
+
+    sub MD5_Init(Blob)                 returns int32 is native(&gen-lib) { * }
+    sub MD5_Update(Blob, Blob, size_t) returns int32 is native(&gen-lib) { * }
+    sub MD5_Final(Blob, Blob)          returns int32 is native(&gen-lib) { * }
+
+    submethod BUILD() {
+        $!context = buf8.allocate(MD5-CTX-SIZE);
+        self.init;
+    }
+
+    method init() {
+        MD5_Init($!context) or die "Bad Call to MD5_Init";
+        return self;
+    }
+
+    multi method add(Str $msg) {
+        self.add($msg.encode('ascii'));
+    }
+
+    multi method add(Blob $msg) {
+        MD5_Update($!context, $msg, $msg.bytes) or die "Bad Call to MD5_Update";
+        return self;
+    }
+
+    method addfile(Str $filename, Int $bufsiz = 64 * 1024) {
+        my $fh = open($filename, :bin) or die "open $filename";
+        LEAVE { .close with $fh }
+        self.add($fh.read($bufsiz)) while not $fh.eof;
+        return self;
+    }
+
+    method hash() {
+        my $digest = buf8.allocate(MD5_DIGEST_LENGTH);
+        MD5_Final($digest, $!context) or die "Bad Call to MD5_Final";
+        self.init;
+        return $digest;
+    }
+
+    method hex() {
+        self.hash.list».fmt("%02x").join;
+    }
+}

--- a/t/06-digest-md5.t
+++ b/t/06-digest-md5.t
@@ -1,0 +1,7 @@
+use Test;
+use OpenSSL::Digest::MD5;
+
+plan 1;
+
+is OpenSSL::Digest::MD5.new.add('abc').hex,
+    '900150983cd24fb0d6963f7d28e17f72', 'hex hash';


### PR DESCRIPTION
Added a OO-interface, OpenSSL::Digest::MD5 interface to openssl MD5_Init(), MD5_Update() and MD5_Final() library calls.
