### PR TITLE
implement subs from jnthn/p6-io-socket-async-ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.precomp

--- a/META6.json
+++ b/META6.json
@@ -1,12 +1,13 @@
 {
     "perl"      : "6.*",
     "name"      : "OpenSSL",
-    "version"   : "0.1.15",
+    "version"   : "1.0.0",
     "author"    : "github:sergot",
     "description"   : "OpenSSL bindings",
     "depends"   : [],
     "provides" : {
         "OpenSSL"             : "lib/OpenSSL.pm6",
+        "OpenSSL::Base"       : "lib/OpenSSL/Base.pm6",
         "OpenSSL::Bio"        : "lib/OpenSSL/Bio.pm6",
         "OpenSSL::Cipher"     : "lib/OpenSSL/Cipher.pm6",
         "OpenSSL::CryptTools" : "lib/OpenSSL/CryptTools.pm6",

--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -9,7 +9,7 @@ use OpenSSL::X509;
 use NativeCall;
 
 has OpenSSL::Ctx::SSL_CTX $.ctx;
-has OpenSSL::SSL::SSL $.ssl;
+has OpenSSL::Base::SSL $.ssl;
 has $.client;
 
 has $.using-bio = False;

--- a/lib/OpenSSL/Base.pm6
+++ b/lib/OpenSSL/Base.pm6
@@ -1,0 +1,35 @@
+unit module OpenSSL::Base;
+
+use OpenSSL::NativeLib;
+use OpenSSL::Bio;
+use OpenSSL::Method;
+
+use NativeCall;
+
+class SSL is repr('CStruct') {
+    has int32 $.version;
+    has int32 $.type;
+
+    has OpenSSL::Method::SSL_METHOD $.method;
+
+    has OpenSSL::Bio::BIO $.rbio;
+    has OpenSSL::Bio::BIO $.wbio;
+    has OpenSSL::Bio::BIO $.bbio;
+
+    has int32 $.rwstate;
+
+    has int32 $.in_handshake;
+
+    # function
+    has OpaquePointer $.handshake_func;
+
+    has int32 $.server;
+
+    has int32 $.new_session;
+
+    has int32 $.quiet_shutdown;
+    has int32 $.shutdown;
+
+    has int32 $.state;
+    has int32 $.rstate;
+}

--- a/lib/OpenSSL/Bio.pm6
+++ b/lib/OpenSSL/Bio.pm6
@@ -37,8 +37,10 @@ class BIO is repr('CStruct') {
     has int32 $.dummy;
 }
 
+our sub BIO_new(BIO_METHOD) returns OpaquePointer is native(&gen-lib) { ... }
 our sub BIO_new_bio_pair(CArray[OpaquePointer], long, CArray[OpaquePointer], long --> int32) is native(&gen-lib) { ... }
 our sub BIO_free(OpaquePointer) is native(&gen-lib) { ... }
 our sub BIO_read(OpaquePointer, Blob, long --> int32) is native(&gen-lib) { ... }
 our sub BIO_write(OpaquePointer, Blob, long --> int32) is native(&gen-lib) { ... }
 our sub BIO_new_mem_buf(Blob, long --> OpaquePointer) is native(&gen-lib) { ... }
+our sub BIO_s_mem() returns BIO_METHOD is native(&gen-lib) { ... }

--- a/lib/OpenSSL/Ctx.pm6
+++ b/lib/OpenSSL/Ctx.pm6
@@ -1,5 +1,6 @@
 unit module OpenSSL::Ctx;
 
+use OpenSSL::Base;
 use OpenSSL::NativeLib;
 use OpenSSL::Method;
 use NativeCall;
@@ -14,3 +15,16 @@ our sub SSL_CTX_free(SSL_CTX) is native(&ssl-lib) { ... }
 our sub SSL_CTX_use_certificate_file(SSL_CTX, Str, int32) returns int32 is native(&ssl-lib) { ... }
 our sub SSL_CTX_use_PrivateKey_file(SSL_CTX, Str, int32) returns int32 is native(&ssl-lib) { ... }
 our sub SSL_CTX_check_private_key(SSL_CTX) returns int32 is native(&ssl-lib) { ... }
+our sub SSL_CTX_set_default_verify_paths(SSL_CTX) is native(&gen-lib) { ... }
+our sub SSL_CTX_load_verify_locations(SSL_CTX, Str, Str) returns int32 is native(&gen-lib) { ... }
+# ALPN
+our sub SSL_CTX_set_alpn_protos(SSL_CTX, Buf, uint32) returns int32 is native(&gen-lib) { ... }
+our sub SSL_CTX_set_alpn_select_cb(SSL_CTX, &callback (
+                                   OpenSSL::Base::SSL,        # ssl
+                                   CArray[CArray[uint8]],    # out
+                                   CArray[uint8],            # outlen
+                                   CArray[uint8],            # in
+                                   uint8,                    # inlen
+                                   Pointer --> int32),       # arg
+                               Pointer)
+    is native(&gen-lib) {*}

--- a/lib/OpenSSL/SSL.pm6
+++ b/lib/OpenSSL/SSL.pm6
@@ -5,58 +5,36 @@ use OpenSSL::Bio;
 use OpenSSL::Method;
 use OpenSSL::Ctx;
 use OpenSSL::Stack;
+use OpenSSL::Base;
 
 use NativeCall;
-
-class SSL is repr('CStruct') {
-    has int32 $.version;
-    has int32 $.type;
-
-    has OpenSSL::Method::SSL_METHOD $.method;
-
-    has OpenSSL::Bio::BIO $.rbio;
-    has OpenSSL::Bio::BIO $.wbio;
-    has OpenSSL::Bio::BIO $.bbio;
-
-    has int32 $.rwstate;
-
-    has int32 $.in_handshake;
-
-    # function
-    has OpaquePointer $.handshake_func;
-
-    has int32 $.server;
-
-    has int32 $.new_session;
-
-    has int32 $.quiet_shutdown;
-    has int32 $.shutdown;
-
-    has int32 $.state;
-    has int32 $.rstate;
-}
 
 our sub SSL_library_init() is native(&ssl-lib)                                 { ... }
 our sub OPENSSL_init_ssl(uint64, OpaquePointer) is native(&ssl-lib)            { ... }
 our sub SSL_load_error_strings() is native(&ssl-lib)                           { ... }
 
-our sub SSL_new(OpenSSL::Ctx::SSL_CTX) returns SSL is native(&ssl-lib)         { ... }
-our sub SSL_set_fd(SSL, int32) returns int32 is native(&ssl-lib)               { ... }
-our sub SSL_shutdown(SSL) returns int32 is native(&ssl-lib)                    { ... }
-our sub SSL_free(SSL) is native(&ssl-lib)                                      { ... }
-our sub SSL_get_error(SSL, int32) returns int32 is native(&ssl-lib)            { ... }
-our sub SSL_accept(SSL) returns int32 is native(&ssl-lib)                      { ... }
-our sub SSL_connect(SSL) returns int32 is native(&ssl-lib)                     { ... }
-our sub SSL_read(SSL, Blob, int32) returns int32 is native(&ssl-lib)  { ... }
-our sub SSL_write(SSL, Blob, int32) returns int32 is native(&ssl-lib) { ... }
-our sub SSL_set_connect_state(SSL) is native(&ssl-lib)                         { ... }
-our sub SSL_set_accept_state(SSL) is native(&ssl-lib)                          { ... }
+our sub SSL_new(OpenSSL::Ctx::SSL_CTX) returns OpenSSL::Base::SSL is native(&ssl-lib)         { ... }
+our sub SSL_set_fd(OpenSSL::Base::SSL, int32) returns int32 is native(&ssl-lib)               { ... }
+our sub SSL_shutdown(OpenSSL::Base::SSL) returns int32 is native(&ssl-lib)                    { ... }
+our sub SSL_free(OpenSSL::Base::SSL) is native(&ssl-lib)                                      { ... }
+our sub SSL_get_error(OpenSSL::Base::SSL, int32) returns int32 is native(&ssl-lib)            { ... }
+our sub SSL_accept(OpenSSL::Base::SSL) returns int32 is native(&ssl-lib)                      { ... }
+our sub SSL_connect(OpenSSL::Base::SSL) returns int32 is native(&ssl-lib)                     { ... }
+our sub SSL_read(OpenSSL::Base::SSL, Blob, int32) returns int32 is native(&ssl-lib)  { ... }
+our sub SSL_write(OpenSSL::Base::SSL, Blob, int32) returns int32 is native(&ssl-lib) { ... }
+our sub SSL_set_connect_state(OpenSSL::Base::SSL) is native(&ssl-lib)                         { ... }
+our sub SSL_set_accept_state(OpenSSL::Base::SSL) is native(&ssl-lib)                          { ... }
 
-our sub SSL_set_bio(SSL, OpaquePointer, OpaquePointer) returns int32 is native(&ssl-lib) { ... }
+our sub SSL_set_bio(OpenSSL::Base::SSL, OpaquePointer, OpaquePointer) returns int32 is native(&ssl-lib) { ... }
 
 our sub SSL_load_client_CA_file(CArray[uint8]) returns OpenSSL::Stack is native(&ssl-lib)  { ... };
-our sub SSL_get_client_CA_list(SSL) returns OpenSSL::Stack is native(&ssl-lib)             { ... };
-our sub SSL_set_client_CA_list(SSL, OpenSSL::Stack) is native(&ssl-lib)                    { ... };
+our sub SSL_get_client_CA_list(OpenSSL::Base::SSL) returns OpenSSL::Stack is native(&ssl-lib)             { ... };
+our sub SSL_set_client_CA_list(OpenSSL::Base::SSL, OpenSSL::Stack) is native(&ssl-lib)                    { ... };
+
+our sub SSL_do_handshake(OpenSSL::Base::SSL) returns int32 is native(&gen-lib) { ... }
+our sub SSL_get_verify_result(OpenSSL::Base::SSL) returns int32 is native(&gen-lib) { ... }
+our sub SSL_get_peer_certificate(OpenSSL::Base::SSL) returns Pointer is native(&gen-lib) { ... }
+our sub SSL_get0_alpn_selected(OpenSSL::Base::SSL, CArray[CArray[uint8]], uint32 is rw) is native(&gen-lib) { ... }
 
 # long SSL_ctrl(SSL *ssl, int cmd, long larg, void *parg)
-our sub SSL_ctrl(SSL, int32, int64, Str ) returns int64 is native(&ssl-lib) { ... }
+our sub SSL_ctrl(OpenSSL::Base::SSL, int32, int64, Str ) returns int64 is native(&ssl-lib) { ... }

--- a/lib/OpenSSL/X509.pm6
+++ b/lib/OpenSSL/X509.pm6
@@ -62,3 +62,8 @@ our sub dump_x509_stack(OpenSSL::Stack $stack, :$FH = $*ERR) {
 
 our sub X509_get_pubkey(OpaquePointer --> OpaquePointer) is native(&gen-lib) { ... }
 our sub X509_free(OpaquePointer) is native(&gen-lib) { ... }
+our sub X509_get_ext_d2i(Pointer, int32, CArray[int32], CArray[int32]) returns OpenSSL::Stack
+    is native(&gen-lib) { ... }
+
+our sub ASN1_STRING_to_UTF8(CArray[CArray[uint8]], Pointer) returns int32
+    is native(&gen-lib) { ... }


### PR DESCRIPTION
also move SSL struct to its own module to avaoid circular dependency
unfortunalety this breaks backward compability, so I had to change
version to 1.0.0

on my road of getting back to my projects and p6 in general I decided to look through some
repos using OpenSSL, I found this https://github.com/jnthn/p6-io-socket-async-ssl/blob/master/lib/IO/Socket/Async/SSL.pm6#L9 and I decided to start with something small :) so here we are...