### PR TITLE
Added SSL_CTX_use_certificate_chain_file import

### DIFF
--- a/lib/OpenSSL/Ctx.pm6
+++ b/lib/OpenSSL/Ctx.pm6
@@ -12,5 +12,6 @@ our sub SSL_CTX_new(OpenSSL::Method::SSL_METHOD) returns SSL_CTX is native(&ssl-
 our sub SSL_CTX_free(SSL_CTX) is native(&ssl-lib) { ... }
 
 our sub SSL_CTX_use_certificate_file(SSL_CTX, Str, int32) returns int32 is native(&ssl-lib) { ... }
+our sub SSL_CTX_use_certificate_chain_file(SSL_CTX, Str) returns int32 is native(&ssl-lib) { ... }
 our sub SSL_CTX_use_PrivateKey_file(SSL_CTX, Str, int32) returns int32 is native(&ssl-lib) { ... }
 our sub SSL_CTX_check_private_key(SSL_CTX) returns int32 is native(&ssl-lib) { ... }


### PR DESCRIPTION
Needed to allow certificate chains containing intermediate certificates to be imported. Tested locally with corresponding changes made to IO::Socket::Async::SSL, works as expected.