### PR TITLE
Stack handling functions; Imports from libcrypto.so; More certificate handling functions

### DIFF
--- a/lib/OpenSSL/Ctx.pm6
+++ b/lib/OpenSSL/Ctx.pm6
@@ -10,7 +10,11 @@ class SSL_CTX is repr('CStruct') {
 
 our sub SSL_CTX_new(OpenSSL::Method::SSL_METHOD) returns SSL_CTX is native(&ssl-lib) { ... }
 our sub SSL_CTX_free(SSL_CTX) is native(&ssl-lib) { ... }
+our sub SSL_CTX_ctrl(SSL_CTX, int32, long, Pointer) returns long is native(&ssl-lib) { ... }
 
+our sub SSL_CTX_use_certificate(SSL_CTX, Pointer) returns int32 is native(&ssl-lib) { ... }
 our sub SSL_CTX_use_certificate_file(SSL_CTX, Str, int32) returns int32 is native(&ssl-lib) { ... }
+our sub SSL_CTX_use_certificate_chain_file(SSL_CTX, Str) returns int32 is native(&ssl-lib) { ... }
+our sub SSL_CTX_use_PrivateKey(SSL_CTX, Pointer) returns int32 is native(&ssl-lib) { ... }
 our sub SSL_CTX_use_PrivateKey_file(SSL_CTX, Str, int32) returns int32 is native(&ssl-lib) { ... }
 our sub SSL_CTX_check_private_key(SSL_CTX) returns int32 is native(&ssl-lib) { ... }

--- a/lib/OpenSSL/NativeLib.pm6
+++ b/lib/OpenSSL/NativeLib.pm6
@@ -12,6 +12,12 @@ sub gen-lib is export {
         !! $*VM.platform-library-name('ssl'.IO).Str;
 }
 
+sub crypto-lib is export {
+    state $lib = $*DISTRO.is-win
+        ?? dll-resource('libeay32.dll')
+        !! $*VM.platform-library-name('crypto'.IO).Str;
+}
+
 # Windows only
 # Problem: The dll files in resources/ don't like to be renamed, but CompUnit::Repository::Installation
 # does not provide a mechanism for storing resources without name mangling. Find::Bundled provided

--- a/lib/OpenSSL/Stack.pm6
+++ b/lib/OpenSSL/Stack.pm6
@@ -1,4 +1,7 @@
+unit module OpenSSL::Stack;
+
 use NativeCall;
+use OpenSSL::NativeLib;
 
 class OpenSSL::Stack is repr('CStruct') {
     has int32 $.num;
@@ -7,3 +10,7 @@ class OpenSSL::Stack is repr('CStruct') {
     has int32 $.num_alloc;
     has Pointer $.comp;
 }
+
+our sub sk_num(OpenSSL::Stack) returns int32 is native(&gen-lib) { ... }
+our sub sk_value(OpenSSL::Stack, int32) returns Pointer is native(&gen-lib) { ... }
+our sub sk_free(OpenSSL::Stack) is native(&gen-lib) { ... }

--- a/lib/OpenSSL/X509.pm6
+++ b/lib/OpenSSL/X509.pm6
@@ -60,5 +60,5 @@ our sub dump_x509_stack(OpenSSL::Stack $stack, :$FH = $*ERR) {
     }
 }
 
-our sub X509_get_pubkey(OpaquePointer --> OpaquePointer) is native(&gen-lib) { ... }
-our sub X509_free(OpaquePointer) is native(&gen-lib) { ... }
+our sub X509_get_pubkey(OpaquePointer --> OpaquePointer) is native(&crypto-lib) { ... }
+our sub X509_free(OpaquePointer) is native(&crypto-lib) { ... }


### PR DESCRIPTION
More imports related to handling certificates and keys in ssl context.
Also imported low level stack handling functions, although more perlish wrapping is still needed.
Added `sub crypto-lib` to import functions residing in `libcrypto.so`