### PR TITLE
Only allocate buffer to max size of an SSL record

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -214,7 +214,7 @@ multi method write(Blob $b) {
 
 method read(Int $n, Bool :$bin) {
     my int32 $count = $n;
-    my $carray = buf8.allocate($n);
+    my $carray = buf8.allocate($n min 16384);
     my $total-read = 0;
     my $buf = buf8.new;
     loop {


### PR DESCRIPTION
According to my interpretation of https://wiki.openssl.org/index.php/Manual:SSL_read(3), if `num` (`$n` here) is larger than the max size of an SSL/TLS record (16k according to https://tools.ietf.org/html/rfc5246#section-6.2.1) it will just return up to a single record.