### PR TITLE
OpenSSL: Negotiate TLS version by default

### DIFF
--- a/lib/OpenSSL.pm6
+++ b/lib/OpenSSL.pm6
@@ -61,8 +61,11 @@ method new(Bool :$client = False, ProtocolVersion :$version = -1) {
         when 1.2 {
             $method = ($client ?? OpenSSL::Method::TLSv1_2_client_method() !! OpenSSL::Method::TLSv1_2_server_method());
         }
+        # No explicit version means: negotiate.
+        # In OpenSSL 1.1.0, TLS_method() replaces SSLv23_method()
         default {
-            $method = try {$client ?? OpenSSL::Method::TLSv1_2_client_method() !! OpenSSL::Method::TLSv1_2_server_method()} || try {$client ?? OpenSSL::Method::TLSv1_client_method() !! OpenSSL::Method::TLSv1_server_method()}  ; 
+            $method = try {$client ?? OpenSSL::Method::TLS_client_method()    !! OpenSSL::Method::TLS_server_method()} \
+                   || try {$client ?? OpenSSL::Method::SSLv23_client_method() !! OpenSSL::Method::SSLv23_server_method()};
         }
     }
     my $ctx     = OpenSSL::Ctx::SSL_CTX_new( $method );
@@ -334,6 +337,7 @@ A module which provides OpenSSL bindings, making us able to set up a TLS/SSL con
     method new(Bool :$client = False, Int :$version?)
 
 A constructor. Initializes OpenSSL library, sets method and context.
+If $version is not specified, the highest possible version is negotiated.
 
 =head2 method set-fd
 

--- a/lib/OpenSSL/Method.pm6
+++ b/lib/OpenSSL/Method.pm6
@@ -16,6 +16,9 @@ our sub SSLv3_method() returns SSL_METHOD is native(&ssl-lib)          { ... }
 our sub SSLv23_client_method() returns SSL_METHOD is native(&ssl-lib)  { ... }
 our sub SSLv23_server_method() returns SSL_METHOD is native(&ssl-lib)  { ... }
 our sub SSLv23_method() returns SSL_METHOD is native(&ssl-lib)         { ... }
+our sub TLS_client_method() returns SSL_METHOD is native(&ssl-lib)     { ... }
+our sub TLS_server_method() returns SSL_METHOD is native(&ssl-lib)     { ... }
+our sub TLS_method() returns SSL_METHOD is native(&ssl-lib)            { ... }
 our sub TLSv1_client_method() returns SSL_METHOD is native(&ssl-lib)   { ... }
 our sub TLSv1_server_method() returns SSL_METHOD is native(&ssl-lib)   { ... }
 our sub TLSv1_method() returns SSL_METHOD is native(&ssl-lib)          { ... }

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -6,16 +6,17 @@ plan 9;
 my $ssl = OpenSSL.new(:version(1), :client);
 
 isa-ok $ssl, OpenSSL, 'new 1/3';
-is $ssl.ctx.method.version, 769, 'new 2/3';
+is $ssl.ctx.method.version, 0x301, 'new 2/3';
 
 $ssl = OpenSSL.new(:client);
-try { OpenSSL::Method::TLSv1_2_client_method() };
-if $!.defined {
-    is $ssl.ctx.method.version, 769, 'new 3/3';
-}
-else {
-    is $ssl.ctx.method.version, 771, 'new 3/3';
-}
+# On OpenSSL 1.1.0, we have TLS_client_method which returns the special
+# value 0x10000. Older OpenSSL use SSLv23_client_method() whose .version
+# is equal to the highest one available.
+   try { OpenSSL::Method::TLS_client_method()     } ?? is $ssl.ctx.method.version, 0x10000, 'new 3/3'
+!! try { OpenSSL::Method::TLSv1_2_client_method() } ?? is $ssl.ctx.method.version, 0x00303, 'new 3/3'
+!! try { OpenSSL::Method::TLSv1_1_client_method() } ?? is $ssl.ctx.method.version, 0x00302, 'new 3/3'
+!! try { OpenSSL::Method::TLSv1_client_method()   } ?? is $ssl.ctx.method.version, 0x00301, 'new 3/3'
+!! flunk 'new 3/3';
 
 # wrong fd here
 ok $ssl.set-fd(111), 'set-fd';


### PR DESCRIPTION
If no $version was given to OpenSSL.new, it would use the highest
TLS version implemented in the OpenSSL library. This is a problem
when you access, via e.g. the WWW module which gives you no access
to the OpenSSL instance, a server which only implements older TLS.

Now, a version negotiating TLS method is used instead if no
explicit $version is requested. Prior to OpenSSL 1.1.0, this
was SSLv23_method() and was then renamed to TLS_method().
See https://wiki.openssl.org/index.php/SSL/TLS_Client#Context_Setup

The OpenSSL documentation SSL_CTX_new(3) recommends to use the
version-flexible methods in applications, so this module should
at least make it available in some form. The manpage even says that
the version-specific methods are deprecated with OpenSSL 1.1.0,
so I guess it isn't too poor practice to potentially allow protocol
downgrades by default.

Now, the 'new 3/3' test in ```01-basic.t``` probes the version selected
by default, so I had to adjust that as well. With OpenSSL 1.1.0, there
is a special method version 0x10000 indicating version negotiation.
Prior to that, the version was set to the same as the highest implemented
method. See:
* Added TLSv1.1: https://github.com/openssl/openssl/blob/637f374ad49d5f6d4f81d87d7cdd226428aa470c/ssl/ssl_locl.h#L673
* Added TLSv1.2: https://github.com/openssl/openssl/blob/49f6cb968ff63793f6671d9026fb2a7034dad79a/ssl/ssl_locl.h#L694

Here's an example that's failing with master but working with this commit:
```perl6
use WWW
use Test
lives-ok { get <https://www.studentenwerk-magdeburg.de/> }
```
```
err code: 337056010
error:1417110A:SSL routines:tls_process_server_hello:wrong ssl version
not ok 1 -
# Failed test at <unknown file> line 1
# Internal Error: 'server returned no data'
```