### PR TITLE
Fix SSL_ctrl on Windows

### DIFF
--- a/lib/OpenSSL/SSL.pm6
+++ b/lib/OpenSSL/SSL.pm6
@@ -59,4 +59,4 @@ our sub SSL_get_client_CA_list(SSL) returns OpenSSL::Stack is native(&ssl-lib)  
 our sub SSL_set_client_CA_list(SSL, OpenSSL::Stack) is native(&ssl-lib)                    { ... };
 
 # long SSL_ctrl(SSL *ssl, int cmd, long larg, void *parg)
-our sub SSL_ctrl(SSL, int32, int64, Str ) returns int64 is native(&ssl-lib) { ... }
+our sub SSL_ctrl(SSL, int32, long, Str ) returns long is native(&ssl-lib) { ... }


### PR DESCRIPTION
OpenSSL.set-server-name() and the test "15-issue-36.t" fail on Windows as the type "long" is 32-bit on that platform. This fix replaces "int64" by "long" in the signature of SSL_ctrl().

Note: I had to change "appveyor.yml" as follows in my repository in order to get a stable Rakudo release that is able to run the tests.

```
     - appveyor-retry git clone https://github.com/rakudo/rakudo.git %APPVEYOR_BUILD_FOLDER%\..\rakudo
     - cd %APPVEYOR_BUILD_FOLDER%\..\rakudo
+    - git checkout 2018.06
```