### PR TITLE
Add OpenSSL::Version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -23,7 +23,8 @@
         "OpenSSL::Stack"      : "lib/OpenSSL/Stack.pm6",
         "OpenSSL::SSL"        : "lib/OpenSSL/SSL.pm6",
         "OpenSSL::X509"       : "lib/OpenSSL/X509.pm6",
-        "OpenSSL::Digest::MD5": "lib/OpenSSL/Digest/MD5.pm6"
+        "OpenSSL::Digest::MD5": "lib/OpenSSL/Digest/MD5.pm6",
+        "OpenSSL::Version"    : "lib/OpenSSL/Version.pm6"
     },
     "source-url"    : "git://github.com/sergot/openssl.git",
     "resources" : [ "ssleay32.dll", "libeay32.dll" ]

--- a/lib/OpenSSL/Stack.pm6
+++ b/lib/OpenSSL/Stack.pm6
@@ -2,6 +2,7 @@ unit module OpenSSL::Stack;
 
 use NativeCall;
 use OpenSSL::NativeLib;
+use OpenSSL::Version;
 
 class OpenSSL::Stack is repr('CStruct') {
     has int32 $.num;
@@ -11,6 +12,11 @@ class OpenSSL::Stack is repr('CStruct') {
     has Pointer $.comp;
 }
 
-our sub sk_num(OpenSSL::Stack) returns int32 is native(&gen-lib) { ... }
-our sub sk_value(OpenSSL::Stack, int32) returns Pointer is native(&gen-lib) { ... }
-our sub sk_free(OpenSSL::Stack) is native(&gen-lib) { ... }
+my sub real_symbol(Str $sym) returns Str {
+    state Int $v = OpenSSL::Version::version_num();
+    return $v >= 0x10100000 ?? "OPENSSL_$sym" !! $sym;
+}
+
+our sub sk_num(OpenSSL::Stack) returns int32 is native(&gen-lib) is symbol(real_symbol('sk_num')) { ... }
+our sub sk_value(OpenSSL::Stack, int32) returns Pointer is native(&gen-lib) is symbol(real_symbol('sk_value')) { ... }
+our sub sk_free(OpenSSL::Stack) is native(&gen-lib) is symbol(real_symbol('sk_free')) { ... }

--- a/lib/OpenSSL/Version.pm6
+++ b/lib/OpenSSL/Version.pm6
@@ -1,0 +1,21 @@
+unit module OpenSSL::Version;
+
+use NativeCall;
+use OpenSSL::NativeLib;
+
+our int32 constant VERSION     = 0;
+our int32 constant CFLAGS      = 1;
+our int32 constant BUILT_ON    = 2;
+our int32 constant PLATFORM    = 3;
+our int32 constant DIR         = 4;
+our int32 constant ENGINES_DIR = 5;
+
+our sub version_num returns Int {
+    my sub OpenSSL_version_num returns ulong is native(&gen-lib) { ... }
+    return try { OpenSSL_version_num() } // 0;
+}
+
+our sub version(int32 $type = VERSION) returns Str {
+    my sub OpenSSL_version(int32) returns Str is native(&gen-lib) { ... }
+    return try { OpenSSL_version($type) } // '';
+}

--- a/t/07-version.t
+++ b/t/07-version.t
@@ -1,0 +1,22 @@
+use Test;
+use OpenSSL::Version;
+
+plan 9;
+
+isa-ok OpenSSL::Version::version_num(), Int, "version_num() is-a 'Int'";
+isa-ok OpenSSL::Version::version(), Str, "version() is-a 'Str'";
+isa-ok OpenSSL::Version::version(OpenSSL::Version::VERSION), Str,
+    "version(VERSION) is-a 'Str'";
+is OpenSSL::Version::version(),
+   OpenSSL::Version::version(OpenSSL::Version::VERSION),
+   'version() eq version(VERSION)';
+isa-ok OpenSSL::Version::version(OpenSSL::Version::CFLAGS), Str,
+   "version(CFLAGS) is-a 'Str'";
+isa-ok OpenSSL::Version::version(OpenSSL::Version::BUILT_ON), Str,
+   "version(BUILT_ON) is-a 'Str'";
+isa-ok OpenSSL::Version::version(OpenSSL::Version::PLATFORM), Str,
+    "version(PLATFORM) is-a 'Str'";
+isa-ok OpenSSL::Version::version(OpenSSL::Version::DIR), Str,
+    "version(DIR) is-a 'Str'";
+isa-ok OpenSSL::Version::version(OpenSSL::Version::ENGINES_DIR), Str,
+    "version(ENGINES_DIR) is-a 'Str'";

--- a/t/10-client-ca-file.t
+++ b/t/10-client-ca-file.t
@@ -7,7 +7,7 @@ my $ssl = OpenSSL.new;
 
 given $ssl.get-client-ca-list {
     isa-ok $_, OpenSSL::Stack, "get-client-ca-list is-a 'OpenSSL::Stack'";
-    ok .num == 0, "get-client-ca-list returned zero entries";
+    ok OpenSSL::Stack::sk_num($_) == 0, "get-client-ca-list returned zero entries";
 }
 
 throws-like {
@@ -17,10 +17,10 @@ throws-like {
 # Copied from the Perl 5 "Mozilla-CA-20160104" CPAN distribution
 given $ssl.use-client-ca-file( $*SPEC.catfile( IO::Path.new($*PROGRAM.dirname).absolute, "cacert.pem" ) ) {
     isa-ok $_, OpenSSL::Stack, "use-client-ca-file is-a 'OpenSSL::Stack'";
-    ok .num > 0, "use-client-ca-list returned >0 entries";
+    ok OpenSSL::Stack::sk_num($_) > 0, "use-client-ca-list returned >0 entries";
 }
 
 given $ssl.get-client-ca-list {
     isa-ok $_, OpenSSL::Stack, "get-client-ca-list is-a 'OpenSSL::Stack'";
-    ok .num > 0, "get-client-ca-list returned >0 entries";
+    ok OpenSSL::Stack::sk_num($_) > 0, "get-client-ca-list returned >0 entries";
 }


### PR DESCRIPTION
This pull request fixes issue #62. The patch adds the module OpenSSL::Version and the functions version_num and version. OpenSSL::Stack uses version_num to define sk_num, sk_value and sk_free, which have been renamed in OpenSSL 1.1.

As mentioned in #64 Rakudo HEAD currently seems to be broken on Windows. See https://ci.appveyor.com/project/voegelas/openssl/build/1.0.17 for a successful build with Rakudo 2018.06. See https://travis-ci.org/voegelas/openssl for a successful Travis build.
