### PR TITLE
Check for LibreSSL

### DIFF
--- a/lib/OpenSSL/Stack.pm6
+++ b/lib/OpenSSL/Stack.pm6
@@ -14,7 +14,8 @@ class OpenSSL::Stack is repr('CStruct') {
 
 my sub real_symbol(Str $sym) returns Str {
     state Int $v = OpenSSL::Version::version_num();
-    return $v >= 0x10100000 ?? "OPENSSL_$sym" !! $sym;
+    state Bool $is_libressl = OpenSSL::Version::version().contains('LibreSSL');
+    return $v >= 0x10100000 && !$is_libressl ?? "OPENSSL_$sym" !! $sym;
 }
 
 our sub sk_num(OpenSSL::Stack) returns int32 is native(&gen-lib) is symbol(real_symbol('sk_num')) { ... }


### PR DESCRIPTION
This patch adds a check for LibreSSL to OpenSSL::Stack. LibreSSL is based on OpenSSL 1.0.2 but returns the version number 2.0.0.

This change fixes the failure in t/10-client-ca-file.t, which is reported in issue #66. The failures in t/01-basic.t are not fixed by this patch.

```
> $*DISTRO
openbsd (6.3)
> use OpenSSL::Version
Nil
> OpenSSL::Version::version()
LibreSSL 2.7.2
> sprintf "%x", OpenSSL::Version::version_num()
20000000
```

See also https://github.com/libressl-portable/openbsd/blob/master/src/lib/libcrypto/opensslv.h