### PR TITLE
RakuDist test for various os

### DIFF
--- a/.rakudist/sparrowfile
+++ b/.rakudist/sparrowfile
@@ -1,0 +1,5 @@
+package-install %(
+  alpine => qqw{make libressl-dev},
+  centos => qqw{openssl openssl-devel},
+  debian => qqw{make libssl-dev},
+);


### PR DESCRIPTION
Hi! I can see OpenSSL fails on some OS, maybe this test suite could be useful for further development.

| os | result | 
|--|--|
| centos | [passed](http://repo.westus.cloudapp.azure.com/rakudist/reports/melezhik/openssl/centos/1580507658.txt) |
| alpine | [failed](http://repo.westus.cloudapp.azure.com/rakudist/reports/melezhik/openssl/alpine/1580507892.txt) |
| debian |[passed](http://repo.westus.cloudapp.azure.com/rakudist/reports/melezhik/openssl/debian/1580509502.txt) | 