### PR TITLE
Fix issues preventing proper packaging of OpenSSL module

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,11 +1,20 @@
 {
+    "meta-version": 1,
     "perl"      : "6.*",
     "name"      : "OpenSSL",
     "version"   : "0.1.23",
     "author"    : "github:sergot",
     "license"   : "MIT",
     "description"   : "OpenSSL bindings",
-    "depends"   : [],
+    "depends"   : {
+        "by-kernel.name": {
+            "win32": ["ssleay32", "libeay32"],
+            "": [
+                {"any": [{"name":"ssl", "from": "native", "ver": "1.1"}, {"name":"ssl", "from": "native", "ver": "1.0"}]},
+                {"any": [{"name":"crypto", "from": "native", "ver": "1.1"}, {"name":"crypto", "from": "native", "ver": "1.0"}]}
+            ]
+        }
+    },
     "provides" : {
         "OpenSSL"             : "lib/OpenSSL.pm6",
         "OpenSSL::Bio"        : "lib/OpenSSL/Bio.pm6",

--- a/META6.json
+++ b/META6.json
@@ -3,6 +3,7 @@
     "name"      : "OpenSSL",
     "version"   : "0.1.23",
     "author"    : "github:sergot",
+    "license"   : "MIT",
     "description"   : "OpenSSL bindings",
     "depends"   : [],
     "provides" : {

--- a/lib/OpenSSL/Bio.pm6
+++ b/lib/OpenSSL/Bio.pm6
@@ -37,8 +37,8 @@ class BIO is repr('CStruct') {
     has int32 $.dummy;
 }
 
-our sub BIO_new_bio_pair(CArray[OpaquePointer], long, CArray[OpaquePointer], long --> int32) is native(&gen-lib) { ... }
-our sub BIO_free(OpaquePointer) is native(&gen-lib) { ... }
-our sub BIO_read(OpaquePointer, Blob, long --> int32) is native(&gen-lib) { ... }
-our sub BIO_write(OpaquePointer, Blob, long --> int32) is native(&gen-lib) { ... }
-our sub BIO_new_mem_buf(Blob, long --> OpaquePointer) is native(&gen-lib) { ... }
+our sub BIO_new_bio_pair(CArray[OpaquePointer], long, CArray[OpaquePointer], long --> int32) is native(gen-lib) { ... }
+our sub BIO_free(OpaquePointer) is native(gen-lib) { ... }
+our sub BIO_read(OpaquePointer, Blob, long --> int32) is native(gen-lib) { ... }
+our sub BIO_write(OpaquePointer, Blob, long --> int32) is native(gen-lib) { ... }
+our sub BIO_new_mem_buf(Blob, long --> OpaquePointer) is native(gen-lib) { ... }

--- a/lib/OpenSSL/Ctx.pm6
+++ b/lib/OpenSSL/Ctx.pm6
@@ -8,13 +8,13 @@ class SSL_CTX is repr('CStruct') {
     has OpenSSL::Method::SSL_METHOD $.method;
 }
 
-our sub SSL_CTX_new(OpenSSL::Method::SSL_METHOD) returns SSL_CTX is native(&ssl-lib) { ... }
-our sub SSL_CTX_free(SSL_CTX) is native(&ssl-lib) { ... }
-our sub SSL_CTX_ctrl(SSL_CTX, int32, long, Pointer) returns long is native(&ssl-lib) { ... }
+our sub SSL_CTX_new(OpenSSL::Method::SSL_METHOD) returns SSL_CTX is native(ssl-lib) { ... }
+our sub SSL_CTX_free(SSL_CTX) is native(ssl-lib) { ... }
+our sub SSL_CTX_ctrl(SSL_CTX, int32, long, Pointer) returns long is native(ssl-lib) { ... }
 
-our sub SSL_CTX_use_certificate(SSL_CTX, Pointer) returns int32 is native(&ssl-lib) { ... }
-our sub SSL_CTX_use_certificate_file(SSL_CTX, Str, int32) returns int32 is native(&ssl-lib) { ... }
-our sub SSL_CTX_use_certificate_chain_file(SSL_CTX, Str) returns int32 is native(&ssl-lib) { ... }
-our sub SSL_CTX_use_PrivateKey(SSL_CTX, Pointer) returns int32 is native(&ssl-lib) { ... }
-our sub SSL_CTX_use_PrivateKey_file(SSL_CTX, Str, int32) returns int32 is native(&ssl-lib) { ... }
-our sub SSL_CTX_check_private_key(SSL_CTX) returns int32 is native(&ssl-lib) { ... }
+our sub SSL_CTX_use_certificate(SSL_CTX, Pointer) returns int32 is native(ssl-lib) { ... }
+our sub SSL_CTX_use_certificate_file(SSL_CTX, Str, int32) returns int32 is native(ssl-lib) { ... }
+our sub SSL_CTX_use_certificate_chain_file(SSL_CTX, Str) returns int32 is native(ssl-lib) { ... }
+our sub SSL_CTX_use_PrivateKey(SSL_CTX, Pointer) returns int32 is native(ssl-lib) { ... }
+our sub SSL_CTX_use_PrivateKey_file(SSL_CTX, Str, int32) returns int32 is native(ssl-lib) { ... }
+our sub SSL_CTX_check_private_key(SSL_CTX) returns int32 is native(ssl-lib) { ... }

--- a/lib/OpenSSL/Digest.pm6
+++ b/lib/OpenSSL/Digest.pm6
@@ -9,11 +9,11 @@ our constant SHA256_DIGEST_LENGTH = 32;
 our constant SHA384_DIGEST_LENGTH = 48;
 our constant SHA512_DIGEST_LENGTH = 64;
 
-sub MD5( Blob, size_t, Blob ) is native(&gen-lib)    { ... }
-sub SHA1( Blob, size_t, Blob ) is native(&gen-lib)   { ... }
-sub SHA256( Blob, size_t, Blob ) is native(&gen-lib) { ... }
-sub SHA384( Blob, size_t, Blob ) is native(&gen-lib) { ... }
-sub SHA512( Blob, size_t, Blob ) is native(&gen-lib) { ... }
+sub MD5( Blob, size_t, Blob ) is native(gen-lib)    { ... }
+sub SHA1( Blob, size_t, Blob ) is native(gen-lib)   { ... }
+sub SHA256( Blob, size_t, Blob ) is native(gen-lib) { ... }
+sub SHA384( Blob, size_t, Blob ) is native(gen-lib) { ... }
+sub SHA512( Blob, size_t, Blob ) is native(gen-lib) { ... }
 
 sub md5(Blob $msg) is export {
      my $digest = buf8.allocate(MD5_DIGEST_LENGTH);

--- a/lib/OpenSSL/Digest/MD5.pm6
+++ b/lib/OpenSSL/Digest/MD5.pm6
@@ -8,9 +8,9 @@ class OpenSSL::Digest::MD5
 {
     has $!context;
 
-    sub MD5_Init(Blob)                 returns int32 is native(&gen-lib) { * }
-    sub MD5_Update(Blob, Blob, size_t) returns int32 is native(&gen-lib) { * }
-    sub MD5_Final(Blob, Blob)          returns int32 is native(&gen-lib) { * }
+    sub MD5_Init(Blob)                 returns int32 is native(gen-lib) { * }
+    sub MD5_Update(Blob, Blob, size_t) returns int32 is native(gen-lib) { * }
+    sub MD5_Final(Blob, Blob)          returns int32 is native(gen-lib) { * }
 
     submethod BUILD() {
         $!context = buf8.allocate(MD5-CTX-SIZE);

--- a/lib/OpenSSL/EVP.pm6
+++ b/lib/OpenSSL/EVP.pm6
@@ -3,19 +3,19 @@ unit module OpenSSL::EVP;
 use OpenSSL::NativeLib;
 use NativeCall;
 
-our sub EVP_PKEY_get1_RSA(OpaquePointer --> OpaquePointer) is native(&gen-lib) { ... }
-our sub EVP_PKEY_free(OpaquePointer) is native(&gen-lib) { ... }
+our sub EVP_PKEY_get1_RSA(OpaquePointer --> OpaquePointer) is native(gen-lib) { ... }
+our sub EVP_PKEY_free(OpaquePointer) is native(gen-lib) { ... }
 
-our sub EVP_CIPHER_CTX_new(--> OpaquePointer) is native(&gen-lib) { ... }
-our sub EVP_CIPHER_CTX_free(OpaquePointer) is native(&gen-lib) { ... }
+our sub EVP_CIPHER_CTX_new(--> OpaquePointer) is native(gen-lib) { ... }
+our sub EVP_CIPHER_CTX_free(OpaquePointer) is native(gen-lib) { ... }
 
-our sub EVP_EncryptInit(OpaquePointer, OpaquePointer, Blob, Blob --> int32) is native(&gen-lib) { ... }
-our sub EVP_EncryptUpdate(OpaquePointer, Blob, CArray[int32], Blob, int32 --> int32) is native(&gen-lib) { ... }
-our sub EVP_EncryptFinal(OpaquePointer, Blob, CArray[int32] --> int32) is native(&gen-lib) { ... }
+our sub EVP_EncryptInit(OpaquePointer, OpaquePointer, Blob, Blob --> int32) is native(gen-lib) { ... }
+our sub EVP_EncryptUpdate(OpaquePointer, Blob, CArray[int32], Blob, int32 --> int32) is native(gen-lib) { ... }
+our sub EVP_EncryptFinal(OpaquePointer, Blob, CArray[int32] --> int32) is native(gen-lib) { ... }
 
-our sub EVP_DecryptInit(OpaquePointer, OpaquePointer, Blob, Blob --> int32) is native(&gen-lib) { ... }
-our sub EVP_DecryptUpdate(OpaquePointer, Blob, CArray[int32], Blob, int32 --> int32) is native(&gen-lib) { ... }
-our sub EVP_DecryptFinal(OpaquePointer, Blob, CArray[int32] --> int32) is native(&gen-lib) { ... }
+our sub EVP_DecryptInit(OpaquePointer, OpaquePointer, Blob, Blob --> int32) is native(gen-lib) { ... }
+our sub EVP_DecryptUpdate(OpaquePointer, Blob, CArray[int32], Blob, int32 --> int32) is native(gen-lib) { ... }
+our sub EVP_DecryptFinal(OpaquePointer, Blob, CArray[int32] --> int32) is native(gen-lib) { ... }
 
 class evp_cipher_st is repr('CStruct') {
     has int32 $.nid;
@@ -34,6 +34,6 @@ class evp_cipher_st is repr('CStruct') {
 }
 
 # ciphers
-our sub EVP_aes_128_cbc( --> OpaquePointer) is native(&gen-lib) { ... }
-our sub EVP_aes_192_cbc( --> OpaquePointer) is native(&gen-lib) { ... }
-our sub EVP_aes_256_cbc( --> OpaquePointer) is native(&gen-lib) { ... }
+our sub EVP_aes_128_cbc( --> OpaquePointer) is native(gen-lib) { ... }
+our sub EVP_aes_192_cbc( --> OpaquePointer) is native(gen-lib) { ... }
+our sub EVP_aes_256_cbc( --> OpaquePointer) is native(gen-lib) { ... }

--- a/lib/OpenSSL/Err.pm6
+++ b/lib/OpenSSL/Err.pm6
@@ -3,6 +3,6 @@ unit module OpenSSL::Err;
 use OpenSSL::NativeLib;
 use NativeCall;
 
-our sub ERR_error_string(int32 $e, Str $ret) returns Str is native(&gen-lib) { ... };
+our sub ERR_error_string(int32 $e, Str $ret) returns Str is native(gen-lib) { ... };
 
-our sub ERR_get_error() returns ulonglong is native(&gen-lib) { ... };
+our sub ERR_get_error() returns ulonglong is native(gen-lib) { ... };

--- a/lib/OpenSSL/Method.pm6
+++ b/lib/OpenSSL/Method.pm6
@@ -13,24 +13,24 @@ class SSL_METHOD is repr('CStruct') {
     has int32 $.version;
 }
 
-our sub SSLv2_client_method() returns SSL_METHOD is native(&ssl-lib)   { ... }
-our sub SSLv2_server_method() returns SSL_METHOD is native(&ssl-lib)   { ... }
-our sub SSLv2_method() returns SSL_METHOD is native(&ssl-lib)          { ... }
-our sub SSLv3_client_method() returns SSL_METHOD is native(&ssl-lib)   { ... }
-our sub SSLv3_server_method() returns SSL_METHOD is native(&ssl-lib)   { ... }
-our sub SSLv3_method() returns SSL_METHOD is native(&ssl-lib)          { ... }
-our sub SSLv23_client_method() returns SSL_METHOD is native(&ssl-lib)  { ... }
-our sub SSLv23_server_method() returns SSL_METHOD is native(&ssl-lib)  { ... }
-our sub SSLv23_method() returns SSL_METHOD is native(&ssl-lib)         { ... }
-our sub TLS_client_method() returns SSL_METHOD is native(&ssl-lib)     { ... }
-our sub TLS_server_method() returns SSL_METHOD is native(&ssl-lib)     { ... }
-our sub TLS_method() returns SSL_METHOD is native(&ssl-lib)            { ... }
-our sub TLSv1_client_method() returns SSL_METHOD is native(&ssl-lib)   { ... }
-our sub TLSv1_server_method() returns SSL_METHOD is native(&ssl-lib)   { ... }
-our sub TLSv1_method() returns SSL_METHOD is native(&ssl-lib)          { ... }
-our sub TLSv1_1_client_method() returns SSL_METHOD is native(&ssl-lib) { ... }
-our sub TLSv1_1_server_method() returns SSL_METHOD is native(&ssl-lib) { ... }
-our sub TLSv1_1_method() returns SSL_METHOD is native(&ssl-lib)        { ... }
-our sub TLSv1_2_client_method() returns SSL_METHOD is native(&ssl-lib) { ... }
-our sub TLSv1_2_server_method() returns SSL_METHOD is native(&ssl-lib) { ... }
-our sub TLSv1_2_method() returns SSL_METHOD is native(&ssl-lib)        { ... }
+our sub SSLv2_client_method() returns SSL_METHOD is native(ssl-lib)   { ... }
+our sub SSLv2_server_method() returns SSL_METHOD is native(ssl-lib)   { ... }
+our sub SSLv2_method() returns SSL_METHOD is native(ssl-lib)          { ... }
+our sub SSLv3_client_method() returns SSL_METHOD is native(ssl-lib)   { ... }
+our sub SSLv3_server_method() returns SSL_METHOD is native(ssl-lib)   { ... }
+our sub SSLv3_method() returns SSL_METHOD is native(ssl-lib)          { ... }
+our sub SSLv23_client_method() returns SSL_METHOD is native(ssl-lib)  { ... }
+our sub SSLv23_server_method() returns SSL_METHOD is native(ssl-lib)  { ... }
+our sub SSLv23_method() returns SSL_METHOD is native(ssl-lib)         { ... }
+our sub TLS_client_method() returns SSL_METHOD is native(ssl-lib)     { ... }
+our sub TLS_server_method() returns SSL_METHOD is native(ssl-lib)     { ... }
+our sub TLS_method() returns SSL_METHOD is native(ssl-lib)            { ... }
+our sub TLSv1_client_method() returns SSL_METHOD is native(ssl-lib)   { ... }
+our sub TLSv1_server_method() returns SSL_METHOD is native(ssl-lib)   { ... }
+our sub TLSv1_method() returns SSL_METHOD is native(ssl-lib)          { ... }
+our sub TLSv1_1_client_method() returns SSL_METHOD is native(ssl-lib) { ... }
+our sub TLSv1_1_server_method() returns SSL_METHOD is native(ssl-lib) { ... }
+our sub TLSv1_1_method() returns SSL_METHOD is native(ssl-lib)        { ... }
+our sub TLSv1_2_client_method() returns SSL_METHOD is native(ssl-lib) { ... }
+our sub TLSv1_2_server_method() returns SSL_METHOD is native(ssl-lib) { ... }
+our sub TLSv1_2_method() returns SSL_METHOD is native(ssl-lib)        { ... }

--- a/lib/OpenSSL/PEM.pm6
+++ b/lib/OpenSSL/PEM.pm6
@@ -3,7 +3,7 @@ unit module OpenSSL::PEM;
 use OpenSSL::NativeLib;
 use NativeCall;
 
-our sub PEM_read_bio_RSAPrivateKey(OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer --> OpaquePointer) is native(&gen-lib) { ... }
-our sub PEM_read_bio_RSAPublicKey(OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer --> OpaquePointer) is native(&gen-lib) { ... }
-our sub PEM_read_bio_RSA_PUBKEY(OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer --> OpaquePointer) is native(&gen-lib) { ... }
-our sub PEM_read_bio_X509(OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer --> OpaquePointer) is native(&gen-lib) { ... }
+our sub PEM_read_bio_RSAPrivateKey(OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer --> OpaquePointer) is native(gen-lib) { ... }
+our sub PEM_read_bio_RSAPublicKey(OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer --> OpaquePointer) is native(gen-lib) { ... }
+our sub PEM_read_bio_RSA_PUBKEY(OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer --> OpaquePointer) is native(gen-lib) { ... }
+our sub PEM_read_bio_X509(OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer --> OpaquePointer) is native(gen-lib) { ... }

--- a/lib/OpenSSL/RSA.pm6
+++ b/lib/OpenSSL/RSA.pm6
@@ -3,8 +3,8 @@ unit module OpenSSL::RSA;
 use OpenSSL::NativeLib;
 use NativeCall;
 
-our sub RSA_sign(int32, Blob, int32, Blob, CArray, OpaquePointer --> int32) is native(&gen-lib) { ... }
-our sub RSA_verify(int32, Blob, int32, Blob, int32, OpaquePointer --> int32) is native(&gen-lib) { ... }
+our sub RSA_sign(int32, Blob, int32, Blob, CArray, OpaquePointer --> int32) is native(gen-lib) { ... }
+our sub RSA_verify(int32, Blob, int32, Blob, int32, OpaquePointer --> int32) is native(gen-lib) { ... }
 
-our sub RSA_size(OpaquePointer --> int32) is native(&gen-lib) { ... }
-our sub RSA_free(OpaquePointer) is native(&gen-lib) { ... }
+our sub RSA_size(OpaquePointer --> int32) is native(gen-lib) { ... }
+our sub RSA_free(OpaquePointer) is native(gen-lib) { ... }

--- a/lib/OpenSSL/SSL.pm6
+++ b/lib/OpenSSL/SSL.pm6
@@ -36,27 +36,27 @@ class SSL is repr('CStruct') {
     has int32 $.rstate;
 }
 
-our sub SSL_library_init() is native(&ssl-lib)                                 { ... }
-our sub OPENSSL_init_ssl(uint64, OpaquePointer) is native(&ssl-lib)            { ... }
-our sub SSL_load_error_strings() is native(&ssl-lib)                           { ... }
+our sub SSL_library_init() is native(ssl-lib)                                 { ... }
+our sub OPENSSL_init_ssl(uint64, OpaquePointer) is native(ssl-lib)            { ... }
+our sub SSL_load_error_strings() is native(ssl-lib)                           { ... }
 
-our sub SSL_new(OpenSSL::Ctx::SSL_CTX) returns SSL is native(&ssl-lib)         { ... }
-our sub SSL_set_fd(SSL, int32) returns int32 is native(&ssl-lib)               { ... }
-our sub SSL_shutdown(SSL) returns int32 is native(&ssl-lib)                    { ... }
-our sub SSL_free(SSL) is native(&ssl-lib)                                      { ... }
-our sub SSL_get_error(SSL, int32) returns int32 is native(&ssl-lib)            { ... }
-our sub SSL_accept(SSL) returns int32 is native(&ssl-lib)                      { ... }
-our sub SSL_connect(SSL) returns int32 is native(&ssl-lib)                     { ... }
-our sub SSL_read(SSL, Blob, int32) returns int32 is native(&ssl-lib)  { ... }
-our sub SSL_write(SSL, Blob, int32) returns int32 is native(&ssl-lib) { ... }
-our sub SSL_set_connect_state(SSL) is native(&ssl-lib)                         { ... }
-our sub SSL_set_accept_state(SSL) is native(&ssl-lib)                          { ... }
+our sub SSL_new(OpenSSL::Ctx::SSL_CTX) returns SSL is native(ssl-lib)         { ... }
+our sub SSL_set_fd(SSL, int32) returns int32 is native(ssl-lib)               { ... }
+our sub SSL_shutdown(SSL) returns int32 is native(ssl-lib)                    { ... }
+our sub SSL_free(SSL) is native(ssl-lib)                                      { ... }
+our sub SSL_get_error(SSL, int32) returns int32 is native(ssl-lib)            { ... }
+our sub SSL_accept(SSL) returns int32 is native(ssl-lib)                      { ... }
+our sub SSL_connect(SSL) returns int32 is native(ssl-lib)                     { ... }
+our sub SSL_read(SSL, Blob, int32) returns int32 is native(ssl-lib)  { ... }
+our sub SSL_write(SSL, Blob, int32) returns int32 is native(ssl-lib) { ... }
+our sub SSL_set_connect_state(SSL) is native(ssl-lib)                         { ... }
+our sub SSL_set_accept_state(SSL) is native(ssl-lib)                          { ... }
 
-our sub SSL_set_bio(SSL, OpaquePointer, OpaquePointer) returns int32 is native(&ssl-lib) { ... }
+our sub SSL_set_bio(SSL, OpaquePointer, OpaquePointer) returns int32 is native(ssl-lib) { ... }
 
-our sub SSL_load_client_CA_file(CArray[uint8]) returns OpenSSL::Stack is native(&ssl-lib)  { ... };
-our sub SSL_get_client_CA_list(SSL) returns OpenSSL::Stack is native(&ssl-lib)             { ... };
-our sub SSL_set_client_CA_list(SSL, OpenSSL::Stack) is native(&ssl-lib)                    { ... };
+our sub SSL_load_client_CA_file(CArray[uint8]) returns OpenSSL::Stack is native(ssl-lib)  { ... };
+our sub SSL_get_client_CA_list(SSL) returns OpenSSL::Stack is native(ssl-lib)             { ... };
+our sub SSL_set_client_CA_list(SSL, OpenSSL::Stack) is native(ssl-lib)                    { ... };
 
 # long SSL_ctrl(SSL *ssl, int cmd, long larg, void *parg)
-our sub SSL_ctrl(SSL, int32, long, Str ) returns long is native(&ssl-lib) { ... }
+our sub SSL_ctrl(SSL, int32, long, Str ) returns long is native(ssl-lib) { ... }

--- a/lib/OpenSSL/Stack.pm6
+++ b/lib/OpenSSL/Stack.pm6
@@ -18,6 +18,6 @@ my sub real_symbol(Str $sym) returns Str {
     return $v >= 0x10100000 && !$is_libressl ?? "OPENSSL_$sym" !! $sym;
 }
 
-our sub sk_num(OpenSSL::Stack) returns int32 is native(&gen-lib) is symbol(real_symbol('sk_num')) { ... }
-our sub sk_value(OpenSSL::Stack, int32) returns Pointer is native(&gen-lib) is symbol(real_symbol('sk_value')) { ... }
-our sub sk_free(OpenSSL::Stack) is native(&gen-lib) is symbol(real_symbol('sk_free')) { ... }
+our sub sk_num(OpenSSL::Stack) returns int32 is native(gen-lib) is symbol(real_symbol('sk_num')) { ... }
+our sub sk_value(OpenSSL::Stack, int32) returns Pointer is native(gen-lib) is symbol(real_symbol('sk_value')) { ... }
+our sub sk_free(OpenSSL::Stack) is native(gen-lib) is symbol(real_symbol('sk_free')) { ... }

--- a/lib/OpenSSL/Version.pm6
+++ b/lib/OpenSSL/Version.pm6
@@ -11,11 +11,11 @@ our int32 constant DIR         = 4;
 our int32 constant ENGINES_DIR = 5;
 
 our sub version_num returns Int {
-    my sub OpenSSL_version_num returns ulong is native(&gen-lib) { ... }
+    my sub OpenSSL_version_num returns ulong is native(gen-lib) { ... }
     return try { OpenSSL_version_num() } // 0;
 }
 
 our sub version(int32 $type = VERSION) returns Str {
-    my sub OpenSSL_version(int32) returns Str is native(&gen-lib) { ... }
+    my sub OpenSSL_version(int32) returns Str is native(gen-lib) { ... }
     return try { OpenSSL_version($type) } // '';
 }

--- a/lib/OpenSSL/X509.pm6
+++ b/lib/OpenSSL/X509.pm6
@@ -60,5 +60,5 @@ our sub dump_x509_stack(OpenSSL::Stack $stack, :$FH = $*ERR) {
     }
 }
 
-our sub X509_get_pubkey(OpaquePointer --> OpaquePointer) is native(&crypto-lib) { ... }
-our sub X509_free(OpaquePointer) is native(&crypto-lib) { ... }
+our sub X509_get_pubkey(OpaquePointer --> OpaquePointer) is native(crypto-lib) { ... }
+our sub X509_free(OpaquePointer) is native(crypto-lib) { ... }


### PR DESCRIPTION
The META6.json file misses information about the license and about the dependency on the native libssl.so library. This PR adds this information. In addition it changes the code for finding the library to first check the versions which we know to work and fall back to the unversioned libssl.so symlink. With this we can get by without an openssl-dev or -devel package installed in many cases.

All of these issues caused pain when packaging the module for Linux distros. With them resolved, the package can be generated fully automatically.