### PR TITLE
Unbreak LibreSSL implementation testing

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl"      : "6.*",
     "name"      : "OpenSSL",
-    "version"   : "0.1.22",
+    "version"   : "0.1.23",
     "author"    : "github:sergot",
     "description"   : "OpenSSL bindings",
     "depends"   : [],

--- a/lib/OpenSSL/Method.pm6
+++ b/lib/OpenSSL/Method.pm6
@@ -4,6 +4,12 @@ use OpenSSL::NativeLib;
 use NativeCall;
 
 class SSL_METHOD is repr('CStruct') {
+    # This field is not present in LibreSSL implementation,
+    # more so this structure is not really meant for introspection.
+    # But for a CStruct we must provide at least one attribute,
+    # so this one is it.
+    # When used with OpenSSL implementation, it returns some values,
+    # otherwise it returns garbage.
     has int32 $.version;
 }
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,22 +1,13 @@
 use OpenSSL;
 use Test;
 
-plan 9;
+plan 7;
 
 my $ssl = OpenSSL.new(:version(1), :client);
 
 isa-ok $ssl, OpenSSL, 'new 1/3';
-is $ssl.ctx.method.version, 0x301, 'new 2/3';
 
 $ssl = OpenSSL.new(:client);
-# On OpenSSL 1.1.0, we have TLS_client_method which returns the special
-# value 0x10000. Older OpenSSL use SSLv23_client_method() whose .version
-# is equal to the highest one available.
-   try { OpenSSL::Method::TLS_client_method()     } ?? is $ssl.ctx.method.version, 0x10000, 'new 3/3'
-!! try { OpenSSL::Method::TLSv1_2_client_method() } ?? is $ssl.ctx.method.version, 0x00303, 'new 3/3'
-!! try { OpenSSL::Method::TLSv1_1_client_method() } ?? is $ssl.ctx.method.version, 0x00302, 'new 3/3'
-!! try { OpenSSL::Method::TLSv1_client_method()   } ?? is $ssl.ctx.method.version, 0x00301, 'new 3/3'
-!! flunk 'new 3/3';
 
 # wrong fd here
 ok $ssl.set-fd(111), 'set-fd';


### PR DESCRIPTION
Do not check OpenSSL specific attribute and properly document it, which allows testing on platform where LibreSSL is used pass.
Fixes https://github.com/sergot/openssl/issues/63
Fixes https://github.com/sergot/openssl/issues/53