### PR TITLE
Fix macOS build; probe openssl libraries in Build.pm6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.precomp/
+resources/libraries.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ perl6:
   - latest
 install:
   - perl6 -v
+  - rakudobrew build-zef
 script:
+  - zef build .
   - NETWORK_TESTING=1 prove -v -e 'perl6 -I.' t/
 sudo: false

--- a/Build.pm6
+++ b/Build.pm6
@@ -1,0 +1,26 @@
+unit class Build;
+
+method build($cwd --> Bool) {
+    my %libraries = ssl => 'ssl', crypto => 'crypto';
+
+    my $prefix;
+    if %*ENV<OPENSSL_PREFIX>:exists {
+        $prefix = %*ENV<OPENSSL_PREFIX>;
+    } elsif !$*DISTRO.is-win {
+        my $proc = run "brew", "--prefix", "openssl", :out, :!err;
+        if ?$proc {
+            $prefix = $proc.out.slurp(:close).chomp;
+        }
+    }
+    if $prefix {
+        note "Using openssl prefix $prefix";
+        %libraries =
+            ssl    => $prefix.IO.child('lib').child('ssl').Str,
+            crypto => $prefix.IO.child('lib').child('crypto').Str,
+        ;
+    }
+
+    my $json = Rakudo::Internals::JSON.to-json: %libraries, :pretty, :sorted-keys;
+    "resources/libraries.json".IO.spurt: $json;
+    return True;
+}

--- a/META6.json
+++ b/META6.json
@@ -27,5 +27,5 @@
         "OpenSSL::Version"    : "lib/OpenSSL/Version.pm6"
     },
     "source-url"    : "git://github.com/sergot/openssl.git",
-    "resources" : [ "ssleay32.dll", "libeay32.dll" ]
+    "resources" : [ "ssleay32.dll", "libeay32.dll", "libraries.json" ]
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ build: off
 
 test_script:
   - SET NETWORK_TESTING=1
+  - perl6 -I. -e "require(q[Build.pm6]); ::(q[Build]).new.build(q[.])"
   - prove -v -e "perl6 -I." t/
 
 shallow_clone: true

--- a/lib/OpenSSL/NativeLib.pm6
+++ b/lib/OpenSSL/NativeLib.pm6
@@ -1,21 +1,23 @@
 unit module OpenSSL::NativeLib;
 
+my %libraries = Rakudo::Internals::JSON.from-json: %?RESOURCES<libraries.json>.slurp(:close);
+
 sub ssl-lib is export {
     state $lib = $*DISTRO.is-win
         ?? dll-resource('ssleay32.dll')
-        !! $*VM.platform-library-name('ssl'.IO).Str;
+        !! $*VM.platform-library-name(%libraries<ssl>.IO).Str;
 }
 
 sub gen-lib is export {
     state $lib = $*DISTRO.is-win
         ?? dll-resource('libeay32.dll')
-        !! $*VM.platform-library-name('ssl'.IO).Str;
+        !! $*VM.platform-library-name(%libraries<ssl>.IO).Str;
 }
 
 sub crypto-lib is export {
     state $lib = $*DISTRO.is-win
         ?? dll-resource('libeay32.dll')
-        !! $*VM.platform-library-name('crypto'.IO).Str;
+        !! $*VM.platform-library-name(%libraries<crypto>.IO).Str;
 }
 
 # Windows only


### PR DESCRIPTION
Currently we cannot install OpenSSL module properly by `zef install OpenSSL` in macOS.
This is because OpenSSL module tries to load libssl/libcrypto from /usr/lib, but they are *incompatible*.

This PR adds Build.pm6, where we probe openssl libraries by `brew --prefix openssl`.

I think it is reasonable to prefer homebrew's openssl;
[Net::SSLeay](https://github.com/radiator-software/p5-net-ssleay/blob/f9ed3412d670edb08d7c9e01e7f92f99602ac728/Makefile.PL#L309), [ruby-build](https://github.com/rbenv/ruby-build/blob/0bd64d37990908876e895aa471685d937f01a034/bin/ruby-build#L1074), [python-build](https://github.com/pyenv/pyenv/blob/6656066d4fefba64ae247956bb35399f98a399c4/plugins/python-build/bin/python-build#L1392) also prefer homebrew's openssl.

This PR will fix #80, #81. 