### PR TITLE
use --installed option while executing brew

### DIFF
--- a/Build.pm6
+++ b/Build.pm6
@@ -7,7 +7,7 @@ method build($cwd --> Bool) {
     if %*ENV<OPENSSL_PREFIX>:exists {
         $prefix = %*ENV<OPENSSL_PREFIX>;
     } elsif !$*DISTRO.is-win {
-        my $proc = run "brew", "--prefix", "openssl", :out, :!err;
+        my $proc = run "brew", "--prefix", "--installed", "openssl", :out, :!err;
         if ?$proc {
             $prefix = $proc.out.slurp(:close).chomp;
         }


### PR DESCRIPTION
I created PR #83 (and it was merged, thanks!), where we used `brew --prefix openssl` to probe openssl libraries.
But it turns out that `brew --prefix openssl` prints a directory even if openssl formula is not installed. I'm sorry.
```
❯ brew --prefix --help
Usage: brew --prefix [--unbrewed] [--installed] [formula ...]
...
If formula is provided, display the location where formula is or would be
installed.
...
      --installed                  Outputs nothing and returns a failing
                                   status code if formula is not installed.
```

This PR adds `--installed` option  to `brew --prefix` command so that `brew --prefix` prints a directory only if openssl formula is actually installed. 