### PR TITLE
Default to OPENSSL_sk_num

### DIFF
--- a/lib/OpenSSL/Stack.pm6
+++ b/lib/OpenSSL/Stack.pm6
@@ -15,7 +15,7 @@ class OpenSSL::Stack is repr('CStruct') {
 my sub real_symbol(Str $sym) returns Str {
     state Int $v = OpenSSL::Version::version_num();
     state Bool $is_libressl = OpenSSL::Version::version().contains('LibreSSL');
-    return $v >= 0x10100000 && !$is_libressl ?? "OPENSSL_$sym" !! $sym;
+    return $is_libressl || 0 < $v < 0x10100000 ?? $sym !! "OPENSSL_$sym";
 }
 
 our sub sk_num(OpenSSL::Stack) returns int32 is native(&gen-lib) is symbol(real_symbol('sk_num')) { ... }


### PR DESCRIPTION
This pull request lets OpenSSL::Stack default to the symbol OPENSSL_sk_num instead of sk_num.
OpenSSL 1.0.2, which provided the old symbol name, is out of support since December 2019.
The issues #82 and #68 and possibly also #72 report problems with sk_num.