### PR TITLE
Delete precomp files when rebuilding 

### DIFF
--- a/Build.pm6
+++ b/Build.pm6
@@ -1,4 +1,5 @@
 use PathTools;
+use JSON::Fast;
 
 unit class Build;
 
@@ -22,7 +23,7 @@ method build($cwd --> Bool) {
         ;
     }
 
-    my $json = Rakudo::Internals::JSON.to-json: %libraries, :pretty, :sorted-keys;
+    my $json = to-json(%libraries, :pretty, :sorted-keys);
     "resources/libraries.json".IO.spurt: $json;
 
     # DO NOT COPY THIS SOLUTION

--- a/Build.pm6
+++ b/Build.pm6
@@ -1,3 +1,5 @@
+use PathTools;
+
 unit class Build;
 
 method build($cwd --> Bool) {
@@ -22,5 +24,13 @@ method build($cwd --> Bool) {
 
     my $json = Rakudo::Internals::JSON.to-json: %libraries, :pretty, :sorted-keys;
     "resources/libraries.json".IO.spurt: $json;
+
+    # DO NOT COPY THIS SOLUTION
+    # Delete precomp files when building in case the openssl libs have since been updated
+    # (ideally this type of stale precomp would get picked up by raku)
+    # see: https://github.com/sergot/openssl/issues/82#issuecomment-864523511
+    try rm($cwd.IO.child('.precomp').absolute, :r, :f, :d);
+    try rm($cwd.IO.child('lib/.precomp').absolute, :r, :f, :d);
+
     return True;
 }

--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "version"   : "0.1.24",
     "author"    : "github:sergot",
     "description"   : "OpenSSL bindings",
-    "build-depends" : ["PathTools"],
+    "build-depends" : ["PathTools","JSON::Fast"],
     "depends"   : [],
     "provides" : {
         "OpenSSL"             : "lib/OpenSSL.pm6",

--- a/META6.json
+++ b/META6.json
@@ -4,6 +4,7 @@
     "version"   : "0.1.24",
     "author"    : "github:sergot",
     "description"   : "OpenSSL bindings",
+    "build-depends" : ["PathTools"],
     "depends"   : [],
     "provides" : {
         "OpenSSL"             : "lib/OpenSSL.pm6",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,14 @@ install:
     - SET PATH=%APPVEYOR_BUILD_FOLDER%\..\rakudo\install\bin;%PATH%
     - SET PATH=%APPVEYOR_BUILD_FOLDER%\..\rakudo\install\share\perl6\site\bin;%PATH%
     - cd %APPVEYOR_BUILD_FOLDER%
+    - git clone https://github.com/ugexe/zef %APPVEYOR_BUILD_FOLDER%\..\zef
+    - raku -I %APPVEYOR_BUILD_FOLDER%\..\zef %APPVEYOR_BUILD_FOLDER%\..\zef\bin\zef --deps-only install .
+    - raku -I %APPVEYOR_BUILD_FOLDER%\..\zef %APPVEYOR_BUILD_FOLDER%\..\zef\bin\zef build .
 
 build: off
 
 test_script:
   - SET NETWORK_TESTING=1
-  - perl6 -I. -e "require(q[Build.pm6]); ::(q[Build]).new.build(q[.])"
-  - prove -v -e "perl6 -I." t/
+  - prove -v -e "raku -I." t/
 
 shallow_clone: true


### PR DESCRIPTION
When updating a native library that an existing precompiled raku module uses there will still be references to the old (now non-existing) native library. This change works around the issue by deleting the precomp files as part of its build step. This helps work around #82