### PR TITLE
Revert "Use JSON::Fast to handle json"

### DIFF
--- a/Build.pm6
+++ b/Build.pm6
@@ -1,5 +1,4 @@
 use PathTools;
-use JSON::Fast;
 
 unit class Build;
 
@@ -23,7 +22,7 @@ method build($cwd --> Bool) {
         ;
     }
 
-    my $json = to-json(%libraries, :pretty, :sorted-keys);
+    my $json = Rakudo::Internals::JSON.to-json: %libraries, :pretty, :sorted-keys;
     "resources/libraries.json".IO.spurt: $json;
 
     # DO NOT COPY THIS SOLUTION

--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "version"   : "0.1.25",
     "author"    : "github:sergot",
     "description"   : "OpenSSL bindings",
-    "build-depends" : ["PathTools","JSON::Fast"],
+    "build-depends" : ["PathTools"],
     "depends"   : [],
     "provides" : {
         "OpenSSL"             : "lib/OpenSSL.pm6",


### PR DESCRIPTION
This reverts commit dcf88a825c65b2727b385452abec5af79811c162.

As described in https://github.com/sergot/openssl/issues/87 that commit
(which is totally fine in principle) unveiled some weird underlying
issue with the precompilation of dependencies for the OpenSSL module.

So, this revert is only a bandaid to unbreak installation of the latest
version (at least on Debian 10)."