### PR TITLE
fix SSL for say (gist) failure as suggested in rakudo ticket 4520

### DIFF
--- a/lib/OpenSSL/Bio.pm6
+++ b/lib/OpenSSL/Bio.pm6
@@ -3,6 +3,11 @@ unit module OpenSSL::Bio;
 use OpenSSL::NativeLib;
 use NativeCall;
 
+class BIO_METHOD is repr('CStruct') {
+    has int32 $.type;
+    has Str $.name;
+}
+
 class BIO is repr('CPointer') {
 }
 


### PR DESCRIPTION


@Xliff See https://github.com/rakudo/rakudo/issues/4520

Fixes the segfault and makes OpenSSL valgrind clean for:
```
use Net::IMAP;
my $i = Net::IMAP.new(server => "imap.gmail.com", :ssl, :debug, port => 993);
say $i.raw.conn.ssl.ssl.WHAT.raku;
say $i.raw.conn.ssl.ssl.defined;
$i.raw.conn.ssl.ssl.say;

```