### PR TITLE
Only deserialize at compile time

### DIFF
--- a/lib/OpenSSL/NativeLib.pm6
+++ b/lib/OpenSSL/NativeLib.pm6
@@ -1,6 +1,6 @@
 unit module OpenSSL::NativeLib;
 
-my %libraries = Rakudo::Internals::JSON.from-json: %?RESOURCES<libraries.json>.slurp(:close);
+BEGIN my %libraries = Rakudo::Internals::JSON.from-json: %?RESOURCES<libraries.json>.slurp(:close);
 
 sub ssl-lib is export {
     state $lib = $*DISTRO.is-win


### PR DESCRIPTION
Without this testing against OpenSSL installed to a CUR::Staging repo fails to find a module in the 'site' repo (despite only having a dependency on NativeCall which is in the 'core' repo).