### PR TITLE
Revert "Revert "Use JSON::Fast to handle json" (#88)"

### DIFF
--- a/Build.pm6
+++ b/Build.pm6
@@ -1,4 +1,5 @@
 use PathTools;
+use JSON::Fast;
 
 unit class Build;
 
@@ -22,7 +23,7 @@ method build($cwd --> Bool) {
         ;
     }
 
-    my $json = Rakudo::Internals::JSON.to-json: %libraries, :pretty, :sorted-keys;
+    my $json = to-json(%libraries, :pretty, :sorted-keys);
     "resources/libraries.json".IO.spurt: $json;
 
     # DO NOT COPY THIS SOLUTION

--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "version"   : "0.1.29",
     "author"    : "github:sergot",
     "description"   : "OpenSSL bindings",
-    "build-depends" : ["PathTools"],
+    "build-depends" : ["PathTools","JSON::Fast"],
     "depends"   : [],
     "provides" : {
         "OpenSSL"             : "lib/OpenSSL.pm6",


### PR DESCRIPTION
This reverts commit 20e89d2e55e4023e0a31dafd7d4bbf2cbfb36a95.

I believe that @patrickbkr and @niner found the real fix for the
spurious failures in OpenSSL::RSAKey with b37d5a0c8b. So the revert,
which only served as a bandaid, is no longer needed.