### PR TITLE
Add binding to AES-128-CTR

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -38,5 +38,5 @@
     "test-depends": [
         "Test"
     ],
-    "version": "0.2.0"
+    "version": "0.2.1"
 }

--- a/lib/OpenSSL/CryptTools.rakumod
+++ b/lib/OpenSSL/CryptTools.rakumod
@@ -17,6 +17,10 @@ multi sub encrypt(:$aes128! where .so, |c) is export {
     my $cipher = OpenSSL::EVP::EVP_aes_128_cbc();
     encrypt(:$cipher, |c);
 }
+multi sub encrypt(:$aes128ctr! where .so, |c) is export {
+    my $cipher = OpenSSL::EVP::EVP_aes_128_ctr();
+    encrypt(:$cipher, |c);
+}
 
 multi sub encrypt(Blob $plaintext, :$key, :$iv, :$cipher! where .so) is export {
     my $ctx = OpenSSL::EVP::EVP_CIPHER_CTX_new();
@@ -64,6 +68,10 @@ multi sub decrypt(:$aes192! where .so, |c) is export {
 }
 multi sub decrypt(:$aes128! where .so, |c) is export {
     my $cipher = OpenSSL::EVP::EVP_aes_128_cbc();
+    decrypt(:$cipher, |c);
+}
+multi sub decrypt(:$aes128ctr! where .so, |c) is export {
+    my $cipher = OpenSSL::EVP::EVP_aes_128_ctr();
     decrypt(:$cipher, |c);
 }
 

--- a/lib/OpenSSL/EVP.rakumod
+++ b/lib/OpenSSL/EVP.rakumod
@@ -37,3 +37,4 @@ class evp_cipher_st is repr('CStruct') {
 our sub EVP_aes_128_cbc( --> OpaquePointer) is native(&gen-lib) { ... }
 our sub EVP_aes_192_cbc( --> OpaquePointer) is native(&gen-lib) { ... }
 our sub EVP_aes_256_cbc( --> OpaquePointer) is native(&gen-lib) { ... }
+our sub EVP_aes_128_ctr( --> OpaquePointer) is native(&gen-lib) { ... }

--- a/t/04-crypt.t
+++ b/t/04-crypt.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 11;
+plan 13;
 
 use OpenSSL::CryptTools;
 
@@ -33,6 +33,11 @@ $ciphertext = encrypt($test, :aes128, :$iv, :$key);
 is-deeply $ciphertext[0..^16], (97,133,236,148,181,60,72,129,145,40,31,27,41,81,165,18), "got aes128 expected ciphertext";
 $plaintext = decrypt($ciphertext, :aes128, :$iv, :$key);
 is-deeply $plaintext[0..^16], $test[0..^16], 'aes128 encrypt/decrypt roundtrip';
+
+$ciphertext = encrypt($test, :aes128ctr, :$iv, :$key);
+is-deeply $ciphertext[0..^16], (32,47,63,22,170,182,213,205,110,114,47,196,218,57,59,113), "got 'aes128ctr expected ciphertext";
+$plaintext = decrypt($ciphertext, :aes128ctr, :$iv, :$key);
+is-deeply $plaintext[0..^16], $test[0..^16], 'aes128ctr encrypt/decrypt roundtrip';
 
 $key.reallocate(192 div 8);
 $ciphertext = encrypt($test, :aes192, :$iv, :$key);


### PR DESCRIPTION
I'm implementing tool to fetch plain private keys from [Geth keystore files](https://geth.ethereum.org/docs/developers/dapp-developer/native-accounts). `AES-128-CTR` cipher is used there.

I added the binding to `EVP_aes_128_ctr()`, followed your code standards and covered new feature with the unit tests.