### PR TITLE
Rework Windows resources hack to not depend on resource path strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         run: brew install openssl
       - name: Install Dependencies
         run: zef install --/test --test-depends --deps-only .
-      - name: Install App::Prove6
-        run: zef install --/test App::Prove6
-      - name: Run Tests
-        run: raku -I. -e "require(q[Build.rakumod]); ::(q[Build]).new.build(q[.])" && prove6 -I. t
+      - name: Build
+        run: zef build .
+      - name: Stage, Test, and Installation
+        run: zef install . --debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,8 @@ jobs:
         run: zef build .
       - name: Stage, Test, and Installation
         run: zef install . --debug
+      - name: Ensure dll rename hack works
+        if: runner.os == 'Windows'
+        run: |
+          Remove-Item -Path $env:TEMP\* -Recurse -Force -ErrorAction Ignore
+          raku ${{ github.workspace }}/t/06-digest-md5.t


### PR DESCRIPTION
Rakudo recently started emitting deprecation messages when `%?RESOURCES` was treated like a path string (see https://github.com/rakudo/rakudo/pull/5507). That affects these openssl bindings because a windows-specific hack was using the base file name of a `%?RESOURCE` entry, which would cause the aforementioned deprecation messages to be emitted. This PR reworks the hack to not depend on any part of the path name.