### PR TITLE
Replace module+class collision with unit class in OpenSSL::Stack

### DIFF
--- a/lib/OpenSSL/Stack.rakumod
+++ b/lib/OpenSSL/Stack.rakumod
@@ -1,16 +1,14 @@
-unit module OpenSSL::Stack;
+unit class OpenSSL::Stack is repr('CStruct');
 
 use NativeCall;
 use OpenSSL::NativeLib;
 use OpenSSL::Version;
 
-class OpenSSL::Stack is repr('CStruct') {
-    has int32 $.num;
-    has CArray[CArray[uint8]] $.data;
-    has int32 $.sorted;
-    has int32 $.num_alloc;
-    has Pointer $.comp;
-}
+has int32 $.num;
+has CArray[CArray[uint8]] $.data;
+has int32 $.sorted;
+has int32 $.num_alloc;
+has Pointer $.comp;
 
 my sub real_symbol(Str $sym) returns Str {
     state Int $v = OpenSSL::Version::version_num();


### PR DESCRIPTION
OpenSSL::Stack.rakumod declared `unit module OpenSSL::Stack;` with a nested `class OpenSSL::Stack is repr('CStruct') { ... }` of the same name. This relied on the traditional Rakudo grammar's silent-replace behavior, where the class overwrites the module in the outer stash. That broken behavior may go away in the future, so we should just rewrite as `unit class OpenSSL::Stack is repr('CStruct');` with the attribute declarations at file scope. This is semantically equivalent to the silent replace outcome and works identically on every Rakudo version: old frontend (silent-replace), new traditional frontend, and RakuAST. The external API is unchanged.