### PR TITLE
Add ALPN, SNI, and negotiated protocol version support

### DIFF
--- a/doc/OpenSSL.rakudoc
+++ b/doc/OpenSSL.rakudoc
@@ -8,9 +8,17 @@ OpenSSL - OpenSSL bindings
 
 =begin code :lang<raku>
 use OpenSSL;
-my $openssl = OpenSSL.new;
-$openssl.set-fd(123);
-$openssl.write("GET / HTTP/1.1\r\nHost: somehost\r\n\r\n");
+
+my $conn = IO::Socket::INET.new: :host<raku.org>, :port(443);
+
+my $openssl = OpenSSL.new(:client);
+$openssl.set-fd($conn.native-descriptor);
+
+$openssl.connect;
+
+$openssl.write("HEAD / HTTP/1.1\r\nHost: raku.org\r\n\r\n");
+say $openssl.read(1024);
+$openssl.close;
 =end code
 
 =head1 DESCRIPTION
@@ -23,11 +31,14 @@ TLS/SSL connection.
 =head2 method new
 
 =begin code :lang<raku>
-method new(Bool :$client = False, Int :$version?)
+method new(Bool :$client = False, ProtocolVersion :$version = -1)
 =end code
 
 A constructor. Initializes OpenSSL library, sets method and context.
-If $version is not specified, the highest possible version is negotiated.
+If C<$version> is not specified, the highest possible version is negotiated.
+
+For client connections, construct the object with C<:client> or call
+C<.set-connect-state> before C<.connect>.
 
 =head2 method set-fd
 
@@ -35,11 +46,9 @@ If $version is not specified, the highest possible version is negotiated.
 method set-fd(OpenSSL:, int32 $fd)
 =end code
 
-Assigns connection's file descriptor (file handle) $fd to the SSL object.
+Assigns connection's file descriptor (file handle) C<$fd> to the SSL object.
 
-To get the $fd we should use C to set up the connection. (See
-L<NativeCall>) I hope we will be able to use Raku's IO::Socket module
-instead of connecting through C soon-ish.
+This must be done before calling C<.connect> or C<.accept>.
 
 =head2 method set-connect-state
 
@@ -50,6 +59,9 @@ method set-connect-state(OpenSSL:)
 Sets SSL object to connect (client) state.
 
 Use it when you want to connect to SSL servers.
+
+If the object was not constructed with C<:client>, call this before
+C<.connect>.
 
 =head2 method set-accept-state
 
@@ -67,9 +79,12 @@ Use it when you want to provide an SSL server.
 method connect(OpenSSL:)
 =end code
 
-Connects to the server using $fd (passed using .set-fd).
+Connects to the server using C<$fd> (passed using C<.set-fd>).
 
 Does all the SSL stuff like handshaking.
+
+For client connections, construct with C<:client> or call
+C<.set-connect-state> first.
 
 =head2 method accept
 
@@ -87,7 +102,7 @@ Does all the SSL stuff like handshaking.
 method write(OpenSSL:, Str $s)
 =end code
 
-Sends $s to the other side (server/client).
+Sends C<$s> to the other side (server/client).
 
 =head2 method read
 
@@ -95,9 +110,9 @@ Sends $s to the other side (server/client).
 method read(OpenSSL:, Int $n, Bool :$bin)
 =end code
 
-Reads $n bytes from the other side (server/client).
+Reads C<$n> bytes from the other side (server/client).
 
-Bool :$bin if we want it to return Buf instead of Str.
+Use C<:$bin> if you want it to return C<Buf> instead of C<Str>.
 
 =head2 method use-certificate-file
 
@@ -105,7 +120,7 @@ Bool :$bin if we want it to return Buf instead of Str.
 method use-certificate-file(OpenSSL:, Str $file)
 =end code
 
-Assings a certificate (from file) to the SSL object.
+Assigns a certificate (from file) to the SSL object.
 
 =head2 method use-privatekey-file
 =begin code :lang<raku>
@@ -113,7 +128,7 @@ method use-privatekey-file(OpenSSL:, Str $file)
 
 =end code
 
-Assings a private key (from file) to the SSL object.
+Assigns a private key (from file) to the SSL object.
 
 =head2 method check-private-key
 
@@ -122,6 +137,77 @@ method check-private-key(OpenSSL:)
 =end code
 
 Checks if private key is valid.
+
+=head2 method version-code
+
+=begin code :lang<raku>
+method version-code(--> Int)
+=end code
+
+Returns the negotiated protocol version as an OpenSSL numeric constant.
+
+This method is useful after a successful C<.connect> or C<.accept>.
+
+=head2 method version-name
+
+=begin code :lang<raku>
+method version-name(--> Str)
+=end code
+
+Returns the negotiated protocol version as a string, for example
+C<TLSv1.2> or C<TLSv1.3>.
+
+This method is useful after a successful C<.connect> or C<.accept>.
+
+=head2 method protocol-version
+
+=begin code :lang<raku>
+method protocol-version(--> ProtocolVersion)
+=end code
+
+Returns the negotiated protocol version normalized to C<ProtocolVersion>.
+
+Returns one of the values accepted by C<ProtocolVersion>, including C<1.3>,
+or C<-1> if the negotiated version is unknown.
+
+This method is useful after a successful C<.connect> or C<.accept>.
+
+=head2 method set-sni-host-name
+
+=begin code :lang<raku>
+method set-sni-host-name(Str $host --> OpenSSL)
+=end code
+
+Sets the TLS SNI (Server Name Indication) host name.
+
+For client connections this should usually be called before C<.connect>,
+especially when connecting to virtual hosts or HTTPS servers by name.
+
+=head2 method set-alpn-protocols
+
+=begin code :lang<raku>
+method set-alpn-protocols(*@protos --> OpenSSL)
+=end code
+
+Sets the ALPN protocols offered by the client, for example
+C<h2> and C<http/1.1>.
+
+This must be called before C<.connect>.
+
+Each protocol must be non-empty and must not exceed 255 bytes.
+
+=head2 method selected-alpn
+
+=begin code :lang<raku>
+method selected-alpn(--> Str)
+=end code
+
+Returns the negotiated ALPN protocol as a string, for example C<h2> or
+C<http/1.1>.
+
+Returns C<Nil> if no ALPN protocol was selected.
+
+This method is useful after a successful C<.connect> or C<.accept>.
 
 =head2 method shutdown
 
@@ -155,7 +241,7 @@ method close(OpenSSL:)
 
 Closes the connection.
 
-Unlike .shutdown it calls ssl-free, ctx-free, and then it shutdowns.
+Unlike C<.shutdown>, this also calls C<.ssl-free> and C<.ctx-free>.
 
 =head1 TOOLS
 

--- a/lib/OpenSSL.rakumod
+++ b/lib/OpenSSL.rakumod
@@ -25,7 +25,7 @@ class X::OpenSSL::Exception is Exception {
 }
 
 # SSLv2 | SSLv3 | TLSv1 | TLSv1.1 | TLSv1.2 | default
-subset ProtocolVersion of Numeric where * == 2| 3| 1| 1.1| 1.2| -1;
+subset ProtocolVersion of Numeric where * == 2| 3| 1| 1.1| 1.2| 1.3| -1;
 
 method new(Bool :$client = False, ProtocolVersion :$version = -1) {
 
@@ -306,6 +306,87 @@ method get-client-ca-list (:$debug is copy) {
 method check-private-key {
     unless OpenSSL::Ctx::SSL_CTX_check_private_key($!ctx) {
         die "Private key does not match the public certificate";
+    }
+}
+
+method protocol-version(--> ProtocolVersion) {
+    given self.version-code {
+        when 0x0300 { 3   }
+        when 0x0301 { 1   }
+        when 0x0302 { 1.1 }
+        when 0x0303 { 1.2 }
+        when 0x0304 { 1.3 }
+        default     { -1  }
+    }
+}
+
+method version-code(--> Int) {
+    with $!ssl {
+        OpenSSL::SSL::SSL_version($!ssl);
+    }
+}
+
+method version-name(--> Str) {
+    with $!ssl {
+        OpenSSL::SSL::SSL_get_version($!ssl);
+    }
+}
+
+method set-sni-host-name(Str $host --> OpenSSL) {
+    with $!ssl {
+        my $rc = OpenSSL::SSL::SSL_ctrl(
+            $!ssl,
+            OpenSSL::SSL::SSL_CTRL_SET_TLSEXT_HOSTNAME,
+            OpenSSL::SSL::TLSEXT_NAMETYPE_host_name,
+            $host
+        );
+        die X::OpenSSL::Exception.new(
+            message => 'SSL_ctrl failed'
+        ) if $rc == 0;
+
+        self
+    }
+}
+
+method set-alpn-protocols(*@protos --> OpenSSL) {
+    with $!ssl {
+        my $wire = Buf.new;
+
+        for @protos -> $proto {
+            my $enc = $proto.encode('ascii');
+
+            die X::OpenSSL::Exception.new(
+                message => "ALPN protocol must not be empty"
+            ) if $enc.elems == 0;
+
+            die X::OpenSSL::Exception.new(
+                message => "ALPN protocol too long (>255 bytes): $proto"
+            ) if $enc.elems > 255;
+
+            $wire.push: $enc.elems;
+            $wire.push: $enc;
+        }
+
+        my $rc = OpenSSL::SSL::SSL_set_alpn_protos($!ssl, $wire, $wire.elems);
+
+        die X::OpenSSL::Exception.new(
+            message => 'SSL_set_alpn_protos failed'
+        ) if $rc != 0;
+
+        self
+    }
+}
+
+method selected-alpn(--> Str) {
+    with $!ssl {
+        my $proto = CArray[CArray[uint8]].new;
+        $proto[0] = CArray[uint8].new;
+        my uint32 $len = 0;
+
+        OpenSSL::SSL::SSL_get0_alpn_selected($!ssl, $proto, $len);
+
+        return Nil if $len == 0;
+        buf8.new($proto[0][^$len]).decode('ascii')
     }
 }
 

--- a/lib/OpenSSL/SSL.rakumod
+++ b/lib/OpenSSL/SSL.rakumod
@@ -8,6 +8,9 @@ use OpenSSL::Stack;
 
 use NativeCall;
 
+constant SSL_CTRL_SET_TLSEXT_HOSTNAME = 55;
+constant TLSEXT_NAMETYPE_host_name    = 0;
+
 class SSL is repr('CStruct') {
     has int32 $.version;
     has int32 $.type;
@@ -106,5 +109,29 @@ our sub SSL_set_client_CA_list(
 our sub SSL_ctrl(
   SSL, int32, long, Str
 --> long) is native(&ssl-lib) { ... }
+
+# const char *SSL_get_version(const SSL *ssl)
+our sub SSL_get_version(
+  SSL
+--> Str) is native(&ssl-lib) { ... }
+
+# int SSL_version(const SSL *s)
+our sub SSL_version(
+  SSL
+--> int32) is native(&ssl-lib) { ... }
+
+# int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
+#                         unsigned int protos_len)
+our sub SSL_set_alpn_protos(
+  SSL, Buf, uint32
+--> int32) is native(&ssl-lib) { ... }
+
+# void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
+#                             unsigned int *len)
+our sub SSL_get0_alpn_selected(
+  SSL,
+  CArray[CArray[uint8]],
+  uint32 is rw
+) is native(&ssl-lib) { ... }
 
 # vim: expandtab shiftwidth=4

--- a/xt/03-alpn-and-version.rakutest
+++ b/xt/03-alpn-and-version.rakutest
@@ -1,0 +1,49 @@
+use Test;
+use OpenSSL;
+use lib 'xt/lib';
+use OpenSSL::TestHelpers;
+
+my @hosts = <raku.org apple.com>;
+
+plan +@hosts * 7;
+
+unless find-program('curl') {
+    skip-rest 'curl is not installed';
+    exit;
+}
+
+for @hosts -> $host {
+    my CurlResult $curl-result = run-curl($host);
+    ok $curl-result.exitcode == 0, "$host: curl exited successfully";
+
+    unless $curl-result.exitcode == 0
+        && $curl-result.tls-version
+        && $curl-result.alpn {
+        skip "$host: curl did not provide TLS/ALPN data", 6;
+        next;
+    }
+
+    my $conn = try IO::Socket::INET.new(:$host, :port(443));
+    ok $conn, "$host: TCP connection established";
+
+    without $conn {
+        skip "$host: could not create TCP connection", 5;
+        next;
+    }
+
+    LEAVE $conn.close with $conn;
+
+    my $openssl = OpenSSL.new(:client);
+    $openssl.set-fd($conn.native-descriptor);
+    lives-ok { $openssl.set-sni-host-name($host) },
+        "$host: SNI setup succeeds";
+    lives-ok { $openssl.set-alpn-protocols('h2', 'http/1.1') },
+        "$host: ALPN setup succeeds";
+    lives-ok { $openssl.connect }, "$host: TLS connect succeeds";
+
+    is $openssl.version-name, $curl-result.tls-version,
+        "$host: TLS version matches curl";
+
+    is $openssl.selected-alpn, $curl-result.alpn,
+        "$host: ALPN matches curl";
+}

--- a/xt/lib/OpenSSL/TestHelpers.rakumod
+++ b/xt/lib/OpenSSL/TestHelpers.rakumod
@@ -1,0 +1,40 @@
+unit module OpenSSL::TestHelpers;
+
+class CurlResult is export {
+    has Int $.exitcode;
+    has Str $.raw-out;
+    has Str $.raw-err;
+
+    has Str $.alpn is rw;
+    has Str $.tls-version is rw;
+}
+
+#| Returns the path to the program if it is found in C<$PATH>, or Nil otherwise
+sub find-program(Str:D $name --> IO::Path) is export {
+    %*ENV<PATH>.split(':').map(*.IO.add($name)).first(*.x)
+}
+
+#| Runs C<curl> and parses its stderr to collect connection details
+sub run-curl(Str:D $host, Int:D :$timeout = 3 --> CurlResult) is export {
+    my $curl = find-program('curl');
+    return Nil without $curl;
+    # C<--write-out '%{json}'> is not enough here because it does not include
+    # the negotiated TLS version
+    my @args = «"$curl" -v -I --connect-timeout $timeout -- "https://$host/"»;
+    my $proc = run @args, :out, :err;
+    my $err = $proc.err.slurp(:close);
+    my $out = $proc.out.slurp(:close);
+
+    my $r = CurlResult.new(
+        :raw-out($out),
+        :raw-err($err),
+        :exitcode($proc.exitcode)
+    );
+
+    given $err {
+        / 'ALPN: server accepted ' (\S+) / and $r.alpn = $0.Str;
+        / 'SSL connection using ' (\S+) / and $r.tls-version = $0.Str;
+    }
+
+    $r
+}


### PR DESCRIPTION
This PR:

- adds ALPN support
- adds methods for retrieving the negotiated protocol version
- adds SNI host name support
- includes small documentation updates

I used the following snippet for manual testing:

```raku
use OpenSSL;

my @hosts = <raku.org apple.com>;

for @hosts -> $host {
    say "--> $host";
    my $conn = IO::Socket::INET.new: :$host, :port(443);
    my $openssl = OpenSSL.new: :client;
    $openssl.set-fd: $conn.native-descriptor;
    $openssl.set-sni-host-name: $host;
    $openssl.set-alpn-protocols('h2', 'http/1.1');
    $openssl.connect;
    say '  version-code: ' ~ sprintf('0x%X', $openssl.version-code);
    say '  version-name: ' ~ $openssl.version-name;
    say '  protocol-version: ' ~ $openssl.protocol-version;
    say '  selected-alpn: ' ~ $openssl.selected-alpn;
    $conn.close;
}
```

On my Linux machine this prints:

```
--> raku.org
  version-code: 0x304
  version-name: TLSv1.3
  protocol-version: 1.3
  selected-alpn: h2
--> apple.com
  version-code: 0x304
  version-name: TLSv1.3
  protocol-version: 1.3
  selected-alpn: http/1.1
```