### PR TITLE
Switch dependency on JSON::Fast to new auth (cpan -> fez)

### DIFF
--- a/Build.rakumod
+++ b/Build.rakumod
@@ -1,5 +1,5 @@
 use File::Directory::Tree:ver<0.2+>:auth<zef:raku-community-modules>;
-use JSON::Fast:ver<0.19+>:auth<cpan:TIMOTIMO>;
+use JSON::Fast:ver<0.20+>:auth<zef:timo>;
 
 unit class Build;
 

--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
   ],
   "build-depends": [
     "File::Directory::Tree:ver<0.2+>:auth<zef:raku-community-modules>",
-    "JSON::Fast:ver<0.19+>:auth<cpan:TIMOTIMO>"
+    "JSON::Fast:ver<0.20+>:auth<zef:timo>"
   ],
   "depends": [
   ],


### PR DESCRIPTION
This not only ensures we pick up future development of JSON::Fast, but also fixes an annoying deprecation warning from the latest JSON::Fast with its auth still on the cpan.