### PR TITLE
Use JSON::Fast at compile time instead of Rakudo::Internals::JSON

### DIFF
--- a/lib/OpenSSL/NativeLib.rakumod
+++ b/lib/OpenSSL/NativeLib.rakumod
@@ -1,6 +1,9 @@
 unit module OpenSSL::NativeLib;
 
-BEGIN my %libraries = Rakudo::Internals::JSON.from-json: %?RESOURCES<libraries.json>.slurp(:close);
+constant %libraries = do {
+    use JSON::Fast;
+    from-json(%?RESOURCES<libraries.json>.slurp(:close));
+}
 
 sub ssl-lib is export {
     state $lib = $*DISTRO.is-win


### PR DESCRIPTION
There was some back-and-forth in the past about this part that handles the data the build script puts in the resources and using JSON::Fast vs not using JSON::Fast, but I would assume that it's now all fine :melting_face: 